### PR TITLE
feat: add async token provider and header adapter to supported models

### DIFF
--- a/Sources/AnyLanguageModel/Models/AnthropicLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/AnthropicLanguageModel.swift
@@ -267,7 +267,10 @@ public struct AnthropicLanguageModel: LanguageModel {
     public let baseURL: URL
 
     /// The closure providing the API key for authentication.
-    private let tokenProvider: @Sendable () -> String
+    private let tokenProvider: @Sendable () async throws -> String
+
+    /// The closure providing custom HTTP headers.
+    private let headerProvider: @Sendable () async throws -> [String: String]
 
     /// The API version to use for requests.
     public let apiVersion: String
@@ -280,11 +283,12 @@ public struct AnthropicLanguageModel: LanguageModel {
 
     private let httpSession: HTTPSession
 
-    /// Creates an Anthropic language model.
+    /// Creates an Anthropic language model with synchronous or static token and header providers.
     ///
     /// - Parameters:
     ///   - baseURL: The base URL for the API endpoint. Defaults to Anthropic's official API.
     ///   - apiKey: Your Anthropic API key or a closure that returns it.
+    ///   - headers: Custom HTTP headers or a closure that returns them.
     ///   - apiVersion: The API version to use for requests. Defaults to `2023-06-01`.
     ///   - betas: Optional beta version(s) of the API to use.
     ///   - model: The model identifier (for example, "claude-3-5-sonnet-20241022").
@@ -292,6 +296,7 @@ public struct AnthropicLanguageModel: LanguageModel {
     public init(
         baseURL: URL = defaultBaseURL,
         apiKey tokenProvider: @escaping @autoclosure @Sendable () -> String,
+        headers headerProvider: @escaping @autoclosure @Sendable () -> [String: String] = [:],
         apiVersion: String = defaultAPIVersion,
         betas: [String]? = nil,
         model: String,
@@ -304,6 +309,40 @@ public struct AnthropicLanguageModel: LanguageModel {
 
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
+        self.apiVersion = apiVersion
+        self.betas = betas
+        self.model = model
+        self.httpSession = session
+    }
+
+    /// Creates an Anthropic language model with asynchronous token and header providers.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL for the API endpoint. Defaults to Anthropic's official API.
+    ///   - apiKey: An asynchronous closure that provides the Anthropic API key.
+    ///   - headers: An asynchronous closure that provides custom HTTP headers.
+    ///   - apiVersion: The API version to use for requests. Defaults to `2023-06-01`.
+    ///   - betas: Optional beta version(s) of the API to use.
+    ///   - model: The model identifier (for example, "claude-3-5-sonnet-20241022").
+    ///   - session: The HTTP session or client used for network requests.
+    public init(
+        baseURL: URL = defaultBaseURL,
+        apiKey tokenProvider: @escaping @Sendable () async throws -> String,
+        headers headerProvider: @escaping @Sendable () async throws -> [String: String] = { [:] },
+        apiVersion: String = defaultAPIVersion,
+        betas: [String]? = nil,
+        model: String,
+        session: HTTPSession = makeDefaultSession(),
+    ) {
+        var baseURL = baseURL
+        if !baseURL.path.hasSuffix("/") {
+            baseURL = baseURL.appendingPathComponent("")
+        }
+
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
         self.apiVersion = apiVersion
         self.betas = betas
         self.model = model
@@ -318,7 +357,7 @@ public struct AnthropicLanguageModel: LanguageModel {
         options: GenerationOptions
     ) async throws -> LanguageModelSession.Response<Content> where Content: Generable {
         let url = baseURL.appendingPathComponent("v1/messages")
-        let headers = buildHeaders()
+        let headers = try await buildHeaders()
 
         // Convert available tools to Anthropic format
         let anthropicTools: [AnthropicTool] = try session.tools.map { tool in
@@ -412,7 +451,7 @@ public struct AnthropicLanguageModel: LanguageModel {
             continuation in
             let task = Task { @Sendable in
                 do {
-                    let headers = buildHeaders()
+                    let headers = try await buildHeaders()
 
                     // Convert available tools to Anthropic format
                     let anthropicTools: [AnthropicTool] = try session.tools.map { tool in
@@ -484,15 +523,18 @@ public struct AnthropicLanguageModel: LanguageModel {
         return LanguageModelSession.ResponseStream(stream: stream)
     }
 
-    private func buildHeaders() -> [String: String] {
+    private func buildHeaders() async throws -> [String: String] {
         var headers: [String: String] = [
-            "x-api-key": tokenProvider(),
+            "x-api-key": try await tokenProvider(),
             "anthropic-version": apiVersion,
         ]
 
         if let betas = betas, !betas.isEmpty {
             headers["anthropic-beta"] = betas.joined(separator: ",")
         }
+
+        let customHeaders = try await headerProvider()
+        headers.merge(customHeaders) { _, new in new }
 
         return headers
     }

--- a/Sources/AnyLanguageModel/Models/GeminiLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/GeminiLanguageModel.swift
@@ -146,7 +146,8 @@ public struct GeminiLanguageModel: LanguageModel {
 
     public let baseURL: URL
 
-    private let tokenProvider: @Sendable () -> String
+    private let tokenProvider: @Sendable () async throws -> String
+    private let headerProvider: @Sendable () async throws -> [String: String]
 
     public let apiVersion: String
 
@@ -188,17 +189,19 @@ public struct GeminiLanguageModel: LanguageModel {
 
     private let httpSession: HTTPSession
 
-    /// Creates a new Gemini language model.
+    /// Creates a new Gemini language model with synchronous token and header providers.
     ///
     /// - Parameters:
     ///   - baseURL: The base URL for the Gemini API.
-    ///   - tokenProvider: A closure that provides the API key.
+    ///   - tokenProvider: A closure or static string providing the API key.
+    ///   - headerProvider: Custom HTTP headers or a closure that returns them.
     ///   - apiVersion: The API version to use.
     ///   - model: The model identifier.
     ///   - session: The HTTP session or client used for network requests.
     public init(
         baseURL: URL = defaultBaseURL,
         apiKey tokenProvider: @escaping @autoclosure @Sendable () -> String,
+        headers headerProvider: @escaping @autoclosure @Sendable () -> [String: String] = [:],
         apiVersion: String = defaultAPIVersion,
         model: String,
         session: HTTPSession = makeDefaultSession(),
@@ -210,6 +213,39 @@ public struct GeminiLanguageModel: LanguageModel {
 
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
+        self.apiVersion = apiVersion
+        self.model = model
+        self._thinking = .disabled
+        self._serverTools = []
+        self.httpSession = session
+    }
+
+    /// Creates a new Gemini language model with asynchronous token and header providers.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL for the Gemini API.
+    ///   - tokenProvider: An asynchronous closure that provides the API key.
+    ///   - headerProvider: An asynchronous closure that provides custom HTTP headers.
+    ///   - apiVersion: The API version to use.
+    ///   - model: The model identifier.
+    ///   - session: The HTTP session or client used for network requests.
+    public init(
+        baseURL: URL = defaultBaseURL,
+        apiKey tokenProvider: @escaping @Sendable () async throws -> String,
+        headers headerProvider: @escaping @Sendable () async throws -> [String: String] = { [:] },
+        apiVersion: String = defaultAPIVersion,
+        model: String,
+        session: HTTPSession = makeDefaultSession(),
+    ) {
+        var baseURL = baseURL
+        if !baseURL.path.hasSuffix("/") {
+            baseURL = baseURL.appendingPathComponent("")
+        }
+
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
         self.apiVersion = apiVersion
         self.model = model
         self._thinking = .disabled
@@ -221,7 +257,8 @@ public struct GeminiLanguageModel: LanguageModel {
     ///
     /// - Parameters:
     ///   - baseURL: The base URL for the Gemini API.
-    ///   - tokenProvider: A closure that provides the API key.
+    ///   - tokenProvider: A closure or static string providing the API key.
+    ///   - headerProvider: Custom HTTP headers or a closure that returns them.
     ///   - apiVersion: The API version to use.
     ///   - model: The model identifier.
     ///   - thinking: The thinking mode configuration.
@@ -239,6 +276,7 @@ public struct GeminiLanguageModel: LanguageModel {
     public init(
         baseURL: URL = defaultBaseURL,
         apiKey tokenProvider: @escaping @autoclosure @Sendable () -> String,
+        headers headerProvider: @escaping @autoclosure @Sendable () -> [String: String] = [:],
         apiVersion: String = defaultAPIVersion,
         model: String,
         thinking: CustomGenerationOptions.Thinking = .disabled,
@@ -252,6 +290,52 @@ public struct GeminiLanguageModel: LanguageModel {
 
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
+        self.apiVersion = apiVersion
+        self.model = model
+        self._thinking = thinking
+        self._serverTools = serverTools
+        self.httpSession = session
+    }
+
+    /// Creates a new Gemini language model with thinking and server tools configuration.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL for the Gemini API.
+    ///   - tokenProvider: An asynchronous closure providing the API key.
+    ///   - headerProvider: An asynchronous closure providing custom HTTP headers.
+    ///   - apiVersion: The API version to use.
+    ///   - model: The model identifier.
+    ///   - thinking: The thinking mode configuration.
+    ///   - serverTools: Server-side tools to enable.
+    ///   - session: The HTTP session or client used for network requests.
+    ///
+    /// - Important: This initializer is deprecated. Use the initializer without
+    ///   `thinking` and `serverTools` parameters, and pass these options through
+    ///   ``GenerationOptions`` instead.
+    @available(
+        *,
+        deprecated,
+        message: "Use init without thinking/serverTools and pass them via GenerationOptions custom options"
+    )
+    public init(
+        baseURL: URL = defaultBaseURL,
+        apiKey tokenProvider: @escaping @Sendable () async throws -> String,
+        headers headerProvider: @escaping @Sendable () async throws -> [String: String] = { [:] },
+        apiVersion: String = defaultAPIVersion,
+        model: String,
+        thinking: CustomGenerationOptions.Thinking = .disabled,
+        serverTools: [CustomGenerationOptions.ServerTool] = [],
+        session: HTTPSession = makeDefaultSession(),
+    ) {
+        var baseURL = baseURL
+        if !baseURL.path.hasSuffix("/") {
+            baseURL = baseURL.appendingPathComponent("")
+        }
+
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
         self.apiVersion = apiVersion
         self.model = model
         self._thinking = thinking
@@ -276,7 +360,7 @@ public struct GeminiLanguageModel: LanguageModel {
             baseURL
             .appendingPathComponent(apiVersion)
             .appendingPathComponent("models/\(model):generateContent")
-        let headers = buildHeaders()
+        let headers = try await buildHeaders()
 
         let geminiTools = try buildTools(from: session.tools, serverTools: effectiveServerTools)
 
@@ -391,7 +475,7 @@ public struct GeminiLanguageModel: LanguageModel {
             continuation in
             let task = Task { @Sendable in
                 do {
-                    let headers = buildHeaders()
+                    let headers = try await buildHeaders()
 
                     let geminiTools = try buildTools(from: session.tools, serverTools: effectiveServerTools)
 
@@ -462,10 +546,12 @@ public struct GeminiLanguageModel: LanguageModel {
         return LanguageModelSession.ResponseStream(stream: stream)
     }
 
-    private func buildHeaders() -> [String: String] {
-        let headers: [String: String] = [
-            "x-goog-api-key": tokenProvider()
+    private func buildHeaders() async throws -> [String: String] {
+        var headers: [String: String] = [
+            "x-goog-api-key": try await tokenProvider()
         ]
+        let customHeaders = try await headerProvider()
+        headers.merge(customHeaders) { _, new in new }
 
         return headers
     }

--- a/Sources/AnyLanguageModel/Models/OpenAILanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/OpenAILanguageModel.swift
@@ -385,7 +385,10 @@ public struct OpenAILanguageModel: LanguageModel {
     public let baseURL: URL
 
     /// The closure providing the API key for authentication.
-    private let tokenProvider: @Sendable () -> String
+    private let tokenProvider: @Sendable () async throws -> String
+
+    /// The closure providing custom HTTP headers.
+    private let headerProvider: @Sendable () async throws -> [String: String]
 
     /// The model identifier to use for generation.
     public let model: String
@@ -395,17 +398,19 @@ public struct OpenAILanguageModel: LanguageModel {
 
     private let httpSession: HTTPSession
 
-    /// Creates an OpenAI language model.
+    /// Creates an OpenAI language model with synchronous or static token and header providers.
     ///
     /// - Parameters:
     ///   - baseURL: The base URL for the API endpoint. Defaults to OpenAI's official API.
     ///   - apiKey: Your OpenAI API key or a closure that returns it.
+    ///   - headers: Custom HTTP headers or a closure that returns them.
     ///   - model: The model identifier (for example, "gpt-4" or "gpt-3.5-turbo").
     ///   - apiVariant: The API variant to use. Defaults to `.chatCompletions`.
     ///   - session: The HTTP session or client used for network requests.
     public init(
         baseURL: URL = defaultBaseURL,
         apiKey tokenProvider: @escaping @autoclosure @Sendable () -> String,
+        headers headerProvider: @escaping @autoclosure @Sendable () -> [String: String] = [:],
         model: String,
         apiVariant: APIVariant = .chatCompletions,
         session: HTTPSession = makeDefaultSession(),
@@ -417,9 +422,49 @@ public struct OpenAILanguageModel: LanguageModel {
 
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
         self.model = model
         self.apiVariant = apiVariant
         self.httpSession = session
+    }
+
+    /// Creates an OpenAI language model with asynchronous token and header providers.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL for the API endpoint. Defaults to OpenAI's official API.
+    ///   - apiKey: An asynchronous closure that provides the OpenAI API key.
+    ///   - headers: An asynchronous closure that provides custom HTTP headers.
+    ///   - model: The model identifier (for example, "gpt-4" or "gpt-3.5-turbo").
+    ///   - apiVariant: The API variant to use. Defaults to `.chatCompletions`.
+    ///   - session: The HTTP session or client used for network requests.
+    public init(
+        baseURL: URL = defaultBaseURL,
+        apiKey tokenProvider: @escaping @Sendable () async throws -> String,
+        headers headerProvider: @escaping @Sendable () async throws -> [String: String] = { [:] },
+        model: String,
+        apiVariant: APIVariant = .chatCompletions,
+        session: HTTPSession = makeDefaultSession(),
+    ) {
+        var baseURL = baseURL
+        if !baseURL.path.hasSuffix("/") {
+            baseURL = baseURL.appendingPathComponent("")
+        }
+
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
+        self.model = model
+        self.apiVariant = apiVariant
+        self.httpSession = session
+    }
+
+    private func buildHeaders() async throws -> [String: String] {
+        var headers = [
+            "Authorization": "Bearer \(try await tokenProvider())"
+        ]
+        let custom = try await headerProvider()
+        headers.merge(custom) { _, new in new }
+        return headers
     }
 
     public func respond<Content>(
@@ -488,9 +533,7 @@ public struct OpenAILanguageModel: LanguageModel {
             let resp: ChatCompletions.Response = try await httpSession.fetch(
                 .post,
                 url: url,
-                headers: [
-                    "Authorization": "Bearer \(tokenProvider())"
-                ],
+                headers: try await buildHeaders(),
                 body: body
             )
 
@@ -596,9 +639,7 @@ public struct OpenAILanguageModel: LanguageModel {
             let resp: Responses.Response = try await httpSession.fetch(
                 .post,
                 url: url,
-                headers: [
-                    "Authorization": "Bearer \(tokenProvider())"
-                ],
+                headers: try await buildHeaders(),
                 body: body
             )
 
@@ -707,9 +748,7 @@ public struct OpenAILanguageModel: LanguageModel {
                                 httpSession.fetchEventStream(
                                     .post,
                                     url: url,
-                                    headers: [
-                                        "Authorization": "Bearer \(tokenProvider())"
-                                    ],
+                                    headers: try await buildHeaders(),
                                     body: body
                                 )
 
@@ -791,9 +830,7 @@ public struct OpenAILanguageModel: LanguageModel {
                                 httpSession.fetchEventStream(
                                     .post,
                                     url: url,
-                                    headers: [
-                                        "Authorization": "Bearer \(tokenProvider())"
-                                    ],
+                                    headers: try await buildHeaders(),
                                     body: body
                                 )
 

--- a/Sources/AnyLanguageModel/Models/OpenResponsesLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/OpenResponsesLanguageModel.swift
@@ -360,23 +360,28 @@ public struct OpenResponsesLanguageModel: LanguageModel {
     public let baseURL: URL
 
     /// Closure that provides the API key for authentication.
-    private let tokenProvider: @Sendable () -> String
+    private let tokenProvider: @Sendable () async throws -> String
+
+    /// Closure that provides custom HTTP headers.
+    private let headerProvider: @Sendable () async throws -> [String: String]
 
     /// Model identifier to use for generation.
     public let model: String
 
     private let httpSession: HTTPSession
 
-    /// Creates an Open Responses language model.
+    /// Creates an Open Responses language model with synchronous or static token and header providers.
     ///
     /// - Parameters:
     ///   - baseURL: Base URL for the API (e.g. `https://api.openai.com/v1/` or `https://openrouter.ai/api/v1/`). Must end with `/`.
     ///   - apiKey: API key or closure that returns it.
+    ///   - headers: Custom HTTP headers or a closure that returns them.
     ///   - model: Model identifier (e.g. `gpt-4o-mini` or provider-specific id).
     ///   - session: The HTTP session or client used for network requests.
     public init(
         baseURL: URL,
         apiKey tokenProvider: @escaping @autoclosure @Sendable () -> String,
+        headers headerProvider: @escaping @autoclosure @Sendable () -> [String: String] = [:],
         model: String,
         session: HTTPSession = makeDefaultSession(),
     ) {
@@ -386,8 +391,44 @@ public struct OpenResponsesLanguageModel: LanguageModel {
         }
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
         self.model = model
         self.httpSession = session
+    }
+
+    /// Creates an Open Responses language model with asynchronous token and header providers.
+    ///
+    /// - Parameters:
+    ///   - baseURL: Base URL for the API (e.g. `https://api.openai.com/v1/` or `https://openrouter.ai/api/v1/`). Must end with `/`.
+    ///   - apiKey: An asynchronous closure that provides the API key.
+    ///   - headers: An asynchronous closure that provides custom HTTP headers.
+    ///   - model: Model identifier (e.g. `gpt-4o-mini` or provider-specific id).
+    ///   - session: The HTTP session or client used for network requests.
+    public init(
+        baseURL: URL,
+        apiKey tokenProvider: @escaping @Sendable () async throws -> String,
+        headers headerProvider: @escaping @Sendable () async throws -> [String: String] = { [:] },
+        model: String,
+        session: HTTPSession = makeDefaultSession(),
+    ) {
+        var baseURL = baseURL
+        if !baseURL.path.hasSuffix("/") {
+            baseURL = baseURL.appendingPathComponent("")
+        }
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.headerProvider = headerProvider
+        self.model = model
+        self.httpSession = session
+    }
+
+    private func buildHeaders() async throws -> [String: String] {
+        var headers = [
+            "Authorization": "Bearer \(try await tokenProvider())"
+        ]
+        let custom = try await headerProvider()
+        headers.merge(custom) { _, new in new }
+        return headers
     }
 
     public func respond<Content>(
@@ -436,7 +477,7 @@ public struct OpenResponsesLanguageModel: LanguageModel {
                             httpSession.fetchEventStream(
                                 .post,
                                 url: url,
-                                headers: ["Authorization": "Bearer \(tokenProvider())"],
+                                headers: try await buildHeaders(),
                                 body: body
                             )
                         var accumulatedText = ""
@@ -508,7 +549,7 @@ public struct OpenResponsesLanguageModel: LanguageModel {
             let resp: OpenResponsesAPI.Response = try await httpSession.fetch(
                 .post,
                 url: url,
-                headers: ["Authorization": "Bearer \(tokenProvider())"],
+                headers: try await buildHeaders(),
                 body: body
             )
 


### PR DESCRIPTION
# Pull Request

## Is it full AI?
**Yes.** This pull request was 100% planned, designed, implemented, tested, and documented by **Antigravity** (AI Coding Assistant).

## What is it?
This PR introduces support for **asynchronous & throwing token providers** (`apiKey`) as well as a dynamic **custom header provider** (`headers`) across API-key-based language models in `AnyLanguageModel` (`OpenAILanguageModel`, `GeminiLanguageModel`, `AnthropicLanguageModel`, and `OpenResponsesLanguageModel`).

## Why?
Previously, the `apiKey` token provider was limited to synchronous closures (`() -> String`). This prevented callers from using asynchronous or fallible logic—such as fetching tokens from the iOS Keychain, requesting OAuth access tokens asynchronously, or retrieving keys from remote actor-based credential stores—directly inside the model initialization.

Furthermore, applications integrating `AnyLanguageModel` often need to inject custom HTTP headers (such as organization IDs, session tokens, or routing metadata). Adding a `headerProvider` closure enables dynamic, per-request header injection without modifying the underlying HTTP transport session.

## What is added?
1. **Async & Throwing Token Providers**:
   - `tokenProvider` stored type updated to `@Sendable () async throws -> String`.
   - Initializers updated to support `apiKey tokenProvider: @escaping @Sendable () async throws -> String`.
2. **Dynamic Header Provider (`headers`)**:
   - Added `headerProvider: @Sendable () async throws -> [String: String]` to model instances.
   - Headers returned by `headerProvider()` are dynamically evaluated and merged into outgoing request headers before every HTTP call.
3. **Overloaded Initializers for Full Backwards Compatibility**:
   - Synchronous `@autoclosure` initializers (`apiKey: "my-key"`, `headers: ["Custom": "Value"]`) are preserved so existing codebases compile without any breaking changes.
   - Asynchronous initializers support explicit closures (`apiKey: { try await fetchKey() }`, `headers: { try await fetchHeaders() }`).
4. **Detailed Doc Comments**:
   - Complete SwiftDoc parameter documentation restored for all overloaded initializers across all 4 modified models.

## How to test?
1. **Build the package**:
   ```bash
   swift build
   ```
2. **Run test suite**:
   ```bash
   swift test
   ```
3. **Verify Synchronous Usage (Backwards Compatibility)**:
   ```swift
   let model = OpenAILanguageModel(
       apiKey: "sk-proj-12345",
       headers: ["X-Organization-Id": "org-123"],
       model: "gpt-4o"
   )
   ```
4. **Verify Asynchronous Usage**:
   ```swift
   let model = GeminiLanguageModel(
       apiKey: {
           try await keychain.getToken()
       },
       headers: {
           let token = try await authManager.getSessionToken()
           return ["X-Session-Token": token]
       },
       model: "gemini-1.5-pro"
   )
   ```
