### PR TITLE
Fix LlamaLanguageModel build against current llama.swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,15 @@
       }
     },
     {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "716419d4d7aa542fce301e809cde7234c68ddbc6",
+        "version" : "2.10549.0"
+      }
+    },
+    {
       "identity" : "partialjsondecoder",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/PartialJSONDecoder",

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -673,8 +673,7 @@ import Foundation
             params.n_gpu_layers = 0
 
             // Try to reduce memory usage
-            params.use_mmap = true
-            params.use_mlock = false
+            params.load_mode = LLAMA_LOAD_MODE_MMAP
             return params
         }
 
@@ -829,6 +828,7 @@ import Foundation
                 llama_sampler_chain_add(
                     samplerPtr,
                     llama_sampler_init_penalties(
+                        llama_vocab_n_tokens(vocab),
                         effectiveRepeatLastN,
                         effectiveRepeatPenalty,
                         effectiveFrequencyPenalty,
@@ -958,6 +958,7 @@ import Foundation
                 llama_sampler_chain_add(
                     samplerPointer,
                     llama_sampler_init_penalties(
+                        llama_vocab_n_tokens(vocab),
                         options.repeatLastN,
                         options.repeatPenalty,
                         options.frequencyPenalty,
@@ -1197,6 +1198,7 @@ import Foundation
                     llama_sampler_chain_add(
                         samplerPtr,
                         llama_sampler_init_penalties(
+                            llama_vocab_n_tokens(vocab),
                             effectiveRepeatLastN,
                             effectiveRepeatPenalty,
                             effectiveFrequencyPenalty,


### PR DESCRIPTION
Current llama.swift releases changed the signature of `llama_sampler_init_penalties`, which takes the vocabulary size as its first argument again. This updates the calls accordingly so the Llama trait builds. The other Llama PRs I am submitting include this commit as their base, so merging this one first collapses them to single-purpose diffs.