### PR TITLE
Enable Metal GPU offload for llama.cpp models by default

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,15 @@
       }
     },
     {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "716419d4d7aa542fce301e809cde7234c68ddbc6",
+        "version" : "2.10549.0"
+      }
+    },
+    {
       "identity" : "partialjsondecoder",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/PartialJSONDecoder",

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -673,8 +673,7 @@ import Foundation
             params.n_gpu_layers = 0
 
             // Try to reduce memory usage
-            params.use_mmap = true
-            params.use_mlock = false
+            params.load_mode = LLAMA_LOAD_MODE_MMAP
             return params
         }
 
@@ -829,6 +828,7 @@ import Foundation
                 llama_sampler_chain_add(
                     samplerPtr,
                     llama_sampler_init_penalties(
+                        llama_vocab_n_tokens(vocab),
                         effectiveRepeatLastN,
                         effectiveRepeatPenalty,
                         effectiveFrequencyPenalty,
@@ -958,6 +958,7 @@ import Foundation
                 llama_sampler_chain_add(
                     samplerPointer,
                     llama_sampler_init_penalties(
+                        llama_vocab_n_tokens(vocab),
                         options.repeatLastN,
                         options.repeatPenalty,
                         options.frequencyPenalty,
@@ -1197,6 +1198,7 @@ import Foundation
                     llama_sampler_chain_add(
                         samplerPtr,
                         llama_sampler_init_penalties(
+                            llama_vocab_n_tokens(vocab),
                             effectiveRepeatLastN,
                             effectiveRepeatPenalty,
                             effectiveFrequencyPenalty,

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -192,6 +192,25 @@ import Foundation
         /// The path to the GGUF model file.
         public let modelPath: String
 
+        /// The number of model layers to offload to the GPU.
+        ///
+        /// A negative value offloads all layers, and `0` runs entirely on the CPU.
+        public let gpuLayers: Int32
+
+        /// The default GPU layer count for the current platform.
+        ///
+        /// All layers are offloaded by default: the prebuilt llama.cpp binaries
+        /// ship with Metal enabled and the shader library embedded. The simulator
+        /// defaults to CPU-only execution, which remains the reliable
+        /// configuration there.
+        public static var defaultGPULayerCount: Int32 {
+            #if targetEnvironment(simulator)
+                return 0
+            #else
+                return -1
+            #endif
+        }
+
         /// The context size for the model.
         ///
         /// - Important: This property is deprecated.
@@ -425,8 +444,11 @@ import Foundation
         ///
         /// - Parameters:
         ///   - modelPath: The path to the GGUF model file.
-        public init(modelPath: String) {
+        ///   - gpuLayers: The number of model layers to offload to the GPU.
+        ///     Defaults to ``defaultGPULayerCount``.
+        public init(modelPath: String, gpuLayers: Int32 = LlamaLanguageModel.defaultGPULayerCount) {
             self.modelPath = modelPath
+            self.gpuLayers = gpuLayers
             self.legacyDefaults = ResolvedGenerationOptions()
         }
 
@@ -668,9 +690,7 @@ import Foundation
 
         private func createModelParams() -> llama_model_params {
             var params = llama_model_default_params()
-
-            // Force CPU-only execution to avoid Metal GPU issues
-            params.n_gpu_layers = 0
+            params.n_gpu_layers = gpuLayers
 
             // Try to reduce memory usage
             params.load_mode = LLAMA_LOAD_MODE_MMAP

--- a/Tests/AnyLanguageModelTests/LlamaLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaLanguageModelTests.swift
@@ -17,6 +17,10 @@ import Testing
         @Test func initialization() {
             let customModel = LlamaLanguageModel(modelPath: "/path/to/model.gguf")
             #expect(customModel.modelPath == "/path/to/model.gguf")
+            #expect(customModel.gpuLayers == LlamaLanguageModel.defaultGPULayerCount)
+
+            let cpuOnlyModel = LlamaLanguageModel(modelPath: "/path/to/model.gguf", gpuLayers: 0)
+            #expect(cpuOnlyModel.gpuLayers == 0)
             #expect(customModel.contextSize == 2048)
             #expect(customModel.batchSize == 512)
             #expect(customModel.threads == Int32(ProcessInfo.processInfo.processorCount))


### PR DESCRIPTION
`n_gpu_layers` was fixed at zero, so every GGUF model ran on CPU even on devices with a capable GPU. This offloads all layers by default on device and keeps CPU execution on the simulator, and it adds a `gpuLayers` initializer parameter for callers that want explicit control. Verified on an iPhone 17 Pro with full layer assignment to Metal.

Includes the build-fix commit from #193 as its base.