### PR TITLE
Cancel the generation when a response stream's consumer stops early

### DIFF
--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -143,7 +143,7 @@ public final class LanguageModelSession: @unchecked Sendable {
         let session = self
         let relay = AsyncThrowingStream<ResponseStream<Content>.Snapshot, any Error> { continuation in
             let stream = upstream
-            Task {
+            let task = Task {
                 session.beginResponding()
                 var lastSnapshot: ResponseStream<Content>.Snapshot?
                 do {
@@ -177,6 +177,11 @@ public final class LanguageModelSession: @unchecked Sendable {
                     continuation.finish(throwing: error)
                 }
                 session.endResponding()
+            }
+            continuation.onTermination = { termination in
+                if case .cancelled = termination {
+                    task.cancel()
+                }
             }
         }
         return ResponseStream(stream: relay)


### PR DESCRIPTION
streamResponse wraps the model's stream in a relay that appends the response to the transcript when generation completes. The relay had no termination handler, so a consumer that stopped iterating early, whether by breaking out of the loop, cancelling its task, or dropping the stream, left the relay consuming and the backend generating to its token limit in the background. That ghost generation kept the model weights and a growing KV cache alive for tens of seconds after the response visibly ended, which surfaces as multi-gigabyte memory spikes and delayed releases on device.

Cancel the relay task when the stream terminates by cancellation. The cancellation propagates through the upstream stream's own termination handler to the backend's generation task, releasing the model promptly. Natural completion still finishes the relay and records the transcript entry exactly as before.

Diagnosed from a memory graph capture showing the model module retained by two suspended task stacks (the relay and the backend generation) long after the consumer had stopped.