### PR TITLE
Remove calls to the deprecated llama_set_warmup

### DIFF
--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -502,7 +502,6 @@ import Foundation
             }
 
             llama_set_causal_attn(context, true)
-            llama_set_warmup(context, false)
             llama_set_n_threads(context, runtimeOptions.threads, runtimeOptions.threads)
 
             let fullPrompt: String
@@ -596,8 +595,7 @@ import Foundation
 
                             // Stabilize runtime behavior per-context
                             llama_set_causal_attn(context, true)
-                            llama_set_warmup(context, false)
-                            llama_set_n_threads(context, runtimeOptions.threads, runtimeOptions.threads)
+                                            llama_set_n_threads(context, runtimeOptions.threads, runtimeOptions.threads)
 
                             var accumulatedText = ""
                             let fullPrompt = try self.formatPrompt(for: session)

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -595,7 +595,7 @@ import Foundation
 
                             // Stabilize runtime behavior per-context
                             llama_set_causal_attn(context, true)
-                                            llama_set_n_threads(context, runtimeOptions.threads, runtimeOptions.threads)
+                            llama_set_n_threads(context, runtimeOptions.threads, runtimeOptions.threads)
 
                             var accumulatedText = ""
                             let fullPrompt = try self.formatPrompt(for: session)


### PR DESCRIPTION
Current llama.cpp builds deprecate `llama_set_warmup` (TAG_LLAMA_GRAPH_NO_WARMUP). Warmup no longer runs implicitly, so calling it with `false` is a no-op, and the header notes the function will be removed.

This removes both call sites in `LlamaLanguageModel`. There is no behavior change