### PR TITLE
Adopt Foundation Models OS 27 surfaces: image attachments, capabilities, context size

### DIFF
--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -405,8 +405,9 @@
                 options.temperature = temperature
             }
 
-            // Note: FoundationModels.GenerationOptions may not have all properties
-            // Only set those that are available
+            if let maximumResponseTokens = self.maximumResponseTokens {
+                options.maximumResponseTokens = maximumResponseTokens
+            }
 
             return options
         }

--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -1,6 +1,8 @@
 #if canImport(FoundationModels)
+    import CoreGraphics
     import FoundationModels
     import Foundation
+    import ImageIO
     import PartialJSONDecoder
 
     import JSONSchema
@@ -53,6 +55,21 @@
             guardrails: FoundationModels.SystemLanguageModel.Guardrails = .default
         ) {
             self.systemModel = FoundationModels.SystemLanguageModel(adapter: adapter, guardrails: guardrails)
+        }
+
+        /// The size of the context window in tokens.
+        nonisolated public var contextSize: Int {
+            systemModel.contextSize
+        }
+
+        /// Whether the model accepts image input.
+        nonisolated public var supportsImageInput: Bool {
+            #if compiler(>=6.4) && !os(tvOS) && !os(watchOS)
+                if #available(macOS 27.0, iOS 27.0, visionOS 27.0, *) {
+                    return systemModel.capabilities.contains(.vision)
+                }
+            #endif
+            return false
         }
 
         /// The availability status for the system language model.
@@ -770,13 +787,46 @@
                             content: fmContent
                         )
                     )
-                case .image:
-                    // FoundationModels Transcript does not support image segments
+                case .image(let imageSegment):
+                    #if compiler(>=6.4) && !os(tvOS)
+                        if #available(macOS 27.0, iOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                            guard let fmImage = FoundationModels.Transcript.ImageAttachment(imageSegment) else {
+                                return nil
+                            }
+                            return .attachment(
+                                .init(
+                                    id: imageSegment.id,
+                                    content: .image(fmImage)
+                                )
+                            )
+                        }
+                    #endif
                     return nil
                 }
             }
         }
     }
+
+    #if compiler(>=6.4) && !os(tvOS)
+        @available(macOS 27.0, iOS 27.0, visionOS 27.0, watchOS 27.0, *)
+        extension FoundationModels.Transcript.ImageAttachment {
+            fileprivate init?(_ imageSegment: Transcript.ImageSegment) {
+                switch imageSegment.source {
+                case .url(let url):
+                    guard url.isFileURL else { return nil }
+                    self.init(imageURL: url)
+                case .data(let data, _):
+                    guard
+                        let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+                        let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil)
+                    else {
+                        return nil
+                    }
+                    self.init(cgImage)
+                }
+            }
+        }
+    #endif
 
     @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension Array where Element == Transcript.ToolDefinition {


### PR DESCRIPTION
This updates the Foundation Models adapter for OS 27 while keeping the package building unchanged on Xcode 26.

Image input: `Transcript` image segments were previously dropped when converting to a FoundationModels transcript. On OS 27 they now map to `Transcript.Segment.attachment` with an `ImageAttachment`, built directly for URL sources and via ImageIO decoding for data sources. Verified end to end on an iPhone running iOS 27 (image prompt answered by the on-device model).

Capabilities and context: `SystemLanguageModel` now exposes `contextSize` (back-deployed by Apple to OS 26) and `supportsImageInput`, which reports the OS 27 `vision` capability and returns false on earlier OS versions.

Generation options: the adapter now sets `maximumResponseTokens` on `FoundationModels.GenerationOptions`. The property has existed since OS 26 but was never assigned, so response token limits were silently ignored on the Foundation Models backend. Verified on device: a capped request now terminates at the limit.

The OS 27 references are behind `#if compiler(>=6.4)` with runtime availability checks, so Xcode 26 builds still compile and the deployment floor is unchanged