### PR TITLE
Fix swift-format lint failure in TranscriptTests

### DIFF
--- a/Tests/AnyLanguageModelTests/TranscriptTests.swift
+++ b/Tests/AnyLanguageModelTests/TranscriptTests.swift
@@ -58,12 +58,14 @@ struct TranscriptTests {
     @Test func sessionRestoresInstructionsFromTranscript() throws {
         let instructions = "First\n\nSecond trailing spaces   "
         let transcript = Transcript(entries: [
-            .instructions(.init(
-                id: "instructions-id",
-                segments: [.text(.init(content: instructions))],
-                toolDefinitions: []
-            )),
-            .prompt(.init(segments: [.text(.init(content: "Hello"))]))
+            .instructions(
+                .init(
+                    id: "instructions-id",
+                    segments: [.text(.init(content: instructions))],
+                    toolDefinitions: []
+                )
+            ),
+            .prompt(.init(segments: [.text(.init(content: "Hello"))])),
         ])
 
         let session = LanguageModelSession(model: MockLanguageModel(), transcript: transcript)


### PR DESCRIPTION
The test added in #156 doesn't pass `swift format lint --strict`, which has failed the Lint step of every CI run on `main` (and on every PR) since 2026-07-02. This reformats `TranscriptTests.swift` so CI can go green again; no behavior change.

`swift format lint --strict --recursive .` is clean on the whole tree after this, and `TranscriptTests` pass.
