### PR TITLE
Raise the macOS CI job timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             swift: "6.2"
             xcode: "26.0"
             traits: "AsyncHTTPClient"
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
The macOS legs build with the MLX, Llama, and CoreML traits and take 6-8 minutes on a cold cache. In the first green run on `main` after #193 and #207 ([run](https://github.com/huggingface/AnyLanguageModel/actions/runs/33633640124)), one job was cancelled at the 10-minute limit during the "Post Cache" step, after Lint, Build, and Test had all passed. Because the cache save gets cut off, the cache never populates and every run stays cold.

This raises the macOS job timeout to 20 minutes. Linux stays at 10.
