### PR TITLE
Drop the duplicated trailing user turn in Foundation Models sessions

### DIFF
--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -382,7 +382,6 @@
         return Transcript(entries: transcript.dropLast())
     }
 
-
     @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension Prompt {
         fileprivate func toFoundationModels() -> FoundationModels.Prompt {

--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -78,7 +78,7 @@
             let fmSession = FoundationModels.LanguageModelSession(
                 model: systemModel,
                 tools: session.tools.toFoundationModels(),
-                transcript: session.transcript.toFoundationModels(
+                transcript: fmTranscriptDroppingDuplicatePrompt(session.transcript, prompt: prompt).toFoundationModels(
                     instructions: session.instructions,
                     toolDefinitions: session.tools
                         .filter(\.includesSchemaInInstructions)
@@ -159,7 +159,7 @@
             let fmSession = FoundationModels.LanguageModelSession(
                 model: systemModel,
                 tools: session.tools.toFoundationModels(),
-                transcript: session.transcript.toFoundationModels(
+                transcript: fmTranscriptDroppingDuplicatePrompt(session.transcript, prompt: prompt).toFoundationModels(
                     instructions: session.instructions,
                     toolDefinitions: session.tools
                         .filter(\.includesSchemaInInstructions)
@@ -366,6 +366,22 @@
     }
 
     // MARK: - Helpers
+
+    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    func fmTranscriptDroppingDuplicatePrompt(_ transcript: Transcript, prompt: Prompt) -> Transcript {
+        guard let lastEntry = transcript.last, case .prompt(let lastPrompt) = lastEntry else {
+            return transcript
+        }
+        let lastText = lastPrompt.segments.compactMap { segment -> String? in
+            if case .text(let textSegment) = segment { return textSegment.content }
+            return nil
+        }.joined()
+        guard lastText == prompt.description else {
+            return transcript
+        }
+        return Transcript(entries: transcript.dropLast())
+    }
+
 
     @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension Prompt {


### PR DESCRIPTION
`LanguageModelSession` appends the prompt entry to its transcript before invoking the model. The Foundation Models adapter then passes that transcript to `FoundationModels.LanguageModelSession` and also sends the prompt through `respond` and `streamResponse`, which appends it again. Every FM-backed turn therefore reaches the model with the final user message duplicated.

The MLX adapter shows the intended contract. It renders the chat from `session.transcript` alone and treats the prompt parameter as a `fallbackPrompt`. FM's API requires passing the prompt separately, so the fix on this adapter is to drop a trailing transcript prompt that matches the outgoing prompt before conversion.

This is directly observable on OS 27 by decoding the rendered prompt of a custom `LanguageModel` backend, where the user turn appears twice. The same transcript construction applies to `SystemLanguageModel` on OS 26, where it wastes prompt tokens on every turn.