### PR TITLE
Cache integer/decimal token sets in ConstrainedJSONGenerator (like the string set already is)

### DIFF
--- a/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
+++ b/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
@@ -46,6 +46,8 @@ private final class StringTokenCache: @unchecked Sendable {
     }
 
     private let tokensByKey = Locked<[Key: Set<Int>]>([:])
+    private let integerTokensByKey = Locked<[Key: Set<Int>]>([:])
+    private let decimalTokensByKey = Locked<[Key: Set<Int>]>([:])
 
     func tokens(for key: Key) -> Set<Int>? {
         tokensByKey.withLock { $0[key] }
@@ -53,6 +55,22 @@ private final class StringTokenCache: @unchecked Sendable {
 
     func store(_ tokens: Set<Int>, for key: Key) {
         tokensByKey.withLock { $0[key] = tokens }
+    }
+
+    func integerTokens(for key: Key) -> Set<Int>? {
+        integerTokensByKey.withLock { $0[key] }
+    }
+
+    func storeIntegerTokens(_ tokens: Set<Int>, for key: Key) {
+        integerTokensByKey.withLock { $0[key] = tokens }
+    }
+
+    func decimalTokens(for key: Key) -> Set<Int>? {
+        decimalTokensByKey.withLock { $0[key] }
+    }
+
+    func storeDecimalTokens(_ tokens: Set<Int>, for key: Key) {
+        decimalTokensByKey.withLock { $0[key] = tokens }
     }
 }
 
@@ -194,6 +212,11 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
     }
 
     private static func buildValidIntegerTokens(backend: Backend) -> Set<Int> {
+        let cacheKey = stringTokenCacheKey(for: backend)
+        if let cached = StringTokenCache.shared.integerTokens(for: cacheKey) {
+            return cached
+        }
+
         var allowed = Set<Int>()
         for token in 0 ..< backend.vocabSize {
             if backend.isSpecialToken(token) { continue }
@@ -204,10 +227,17 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
                 allowed.insert(token)
             }
         }
+
+        StringTokenCache.shared.storeIntegerTokens(allowed, for: cacheKey)
         return allowed
     }
 
     private static func buildValidDecimalTokens(backend: Backend) -> Set<Int> {
+        let cacheKey = stringTokenCacheKey(for: backend)
+        if let cached = StringTokenCache.shared.decimalTokens(for: cacheKey) {
+            return cached
+        }
+
         var allowed = Set<Int>()
         for token in 0 ..< backend.vocabSize {
             if backend.isSpecialToken(token) { continue }
@@ -218,6 +248,8 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
                 allowed.insert(token)
             }
         }
+
+        StringTokenCache.shared.storeDecimalTokens(allowed, for: cacheKey)
         return allowed
     }
 


### PR DESCRIPTION
## Problem

`ConstrainedJSONGenerator.init` unconditionally calls `buildValidIntegerTokens`
and `buildValidDecimalTokens` on every construction (`Sources/AnyLanguageModel/Shared/StructuredGeneration.swift:110-111`).
Each does a full `0 ..< backend.vocabSize` scan and, per token, calls
`backend.isSpecialToken(token)` and `backend.tokenText(token)`. On the MLX
backend, `isSpecialToken` calls `tokenizer.decode(tokens:skipSpecialTokens:)`
twice and `tokenText` calls it once more — three tokenizer decode calls per
vocab entry.

On a 151,936-token vocabulary (Qwen3-1.7B), that's ~456K decode calls per
scan, ~911K for the pair, on **every single `ConstrainedJSONGenerator`
construction** — regardless of whether the schema being constrained contains
any numeric field at all (the scan isn't gated on schema content).

`buildValidStringTokens` already solves this exact problem: it's memoized in
`StringTokenCache`, keyed by tokenizer identity (`vocabSize`/`eosToken`/`endTokens`/`sampleTexts`).
The integer and decimal scans had no such cache.

## Fix

Mirror the existing `StringTokenCache` pattern for the integer and decimal
scans: two new sibling `Locked<[Key: Set<Int>]>` dictionaries, with a
guard-and-store block around each build function. No other behavior change.

## Measured (Qwen3-1.7B-4bit/MLX, Apple Silicon, M-series)

- Each scan: 1.8–1.9s cold → 44µs/17µs on cache hit (five to six orders of
  magnitude).
- End-to-end constrained generation (one call = one `ConstrainedJSONGenerator`
  construction): 9.9–12.3s → 6.2–8.6s, a ~30–40% reduction in the warm decode
  floor.
- Output verified unchanged: cached token sets are byte-identical to their
  uncached computation, so this cannot itself introduce nondeterminism.

## Testing

`git apply --check` verified clean against `0.8.0` (163f3855). Manual
instrumentation (temporary `ContinuousClock` prints, not part of this diff)
confirmed cache hits on the second call within the same process. No existing
test coverage exercises `ConstrainedJSONGenerator` timing directly, so this
is a pure perf fix with no behavior change to verify against.