### PR TITLE
Require llama.swift 2.10549.0 and free the lazy bitmap for rejected video input

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
             ]
         ),
         .package(url: "https://github.com/mattt/JSONSchema", from: "1.3.0"),
-        .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "2.7484.0")),
+        .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "2.10549.0")),
         .package(url: "https://github.com/mattt/PartialJSONDecoder", from: "1.0.0"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "602.0.0"),

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -1425,6 +1425,9 @@ import Foundation
                         )
                     }
                     if let videoContext = wrapper.video_ctx {
+                        if let bitmap = wrapper.bitmap {
+                            mtmd_bitmap_free(bitmap)
+                        }
                         mtmd_helper_video_free(videoContext)
                         throw LlamaLanguageModelError.unsupportedFeature
                     }


### PR DESCRIPTION
Two follow-ups to #213.

- `Package.swift` still allowed llama.swift from 2.7484.0, but the four-argument `mtmd_helper_bitmap_init_from_buf` that returns `mtmd_helper_bitmap_wrapper` first appears in llama.cpp b10549 (b7484 has the three-argument form returning `mtmd_bitmap *`). A consumer resolving an older 2.x with the Llama trait would fail to compile, so the floor moves to 2.10549.0, which `Package.resolved` already pins.
- When the helper decodes a buffer as video, it returns a lazily initialized bitmap alongside the video context. The rejected-video path freed only the context, so the bitmap leaked. Free both before throwing.