### PR TITLE
Finish a response stream only after its transcript entries are committed

### DIFF
--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -151,9 +151,11 @@ public final class LanguageModelSession: @unchecked Sendable {
                         lastSnapshot = snapshot
                         continuation.yield(snapshot)
                     }
-                    continuation.finish()
 
-                    // Add response to transcript after stream completes
+                    // Commit the response to the transcript
+                    // before the stream reports completion,
+                    // so a caller that drains the stream
+                    // and starts the next turn sees the full history.
                     if let lastSnapshot {
                         // Extract text content from the generated content
                         let textContent: String
@@ -176,10 +178,12 @@ public final class LanguageModelSession: @unchecked Sendable {
                             }
                         }
                     }
+                    session.endResponding()
+                    continuation.finish()
                 } catch {
+                    session.endResponding()
                     continuation.finish(throwing: error)
                 }
-                session.endResponding()
             }
             continuation.onTermination = { termination in
                 if case .cancelled = termination {


### PR DESCRIPTION
Follow-up to #181 (Copilot's one finding there, which predates that PR).

`wrapStream` reported completion before appending the response, and since #181 the streamed tool entries, to the session transcript. A caller that drains the stream and immediately starts the next turn could build its prompt from an incomplete transcript. Now the entries are committed and `isResponding` is cleared first, then the stream finishes, on both the success and the error path.

Default suite: 340 tests pass locally.