### PR TITLE
Serialize lazy loading in LlamaLanguageModel

### DIFF
--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -470,7 +470,11 @@ import Foundation
             return try body()
         }
 
-        /// Whether the model is currently loaded
+        /// Serializes the loaded-state check, loading, and publication of the model,
+        /// vocabulary, and projector so concurrent first requests cannot reload them.
+        private let modelLoadLock = NSLock()
+
+        /// Whether the model is currently loaded. Protected by `modelLoadLock`.
         private var isModelLoaded: Bool = false
 
         /// A context kept alive for one session so exchanges reuse its state.
@@ -788,7 +792,7 @@ import Foundation
             if mmprojPath == nil {
                 try validateNoImageSegments(in: session)
             }
-            try await ensureModelLoaded()
+            try ensureModelLoaded()
 
             let runtimeOptions = resolvedOptions(from: options)
             let structuredOptions = resolvedStructuredOptions(from: options)
@@ -905,7 +909,7 @@ import Foundation
                 AsyncThrowingStream { continuation in
                     let task = Task {
                         do {
-                            try await ensureModelLoaded()
+                            try ensureModelLoaded()
 
                             let runtimeOptions = resolvedOptions(from: options)
                             let maxTokens = runtimeOptions.maximumResponseTokens ?? 100
@@ -970,7 +974,10 @@ import Foundation
 
         // MARK: - Private Helpers
 
-        private func ensureModelLoaded() async throws {
+        private func ensureModelLoaded() throws {
+            modelLoadLock.lock()
+            defer { modelLoadLock.unlock() }
+
             guard !isModelLoaded else { return }
 
             // Check if model file exists

--- a/Tests/AnyLanguageModelTests/LlamaLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaLanguageModelTests.swift
@@ -31,6 +31,28 @@ import Testing
             #expect(customModel.repeatLastN == 64)
         }
 
+        @Test func concurrentFirstRequests() async throws {
+            try await withThrowingTaskGroup(of: String.self) { group in
+                for _ in 0 ..< 2 {
+                    group.addTask {
+                        let session = LanguageModelSession(model: model)
+                        let response = try await session.respond(
+                            to: "Reply with a single word.",
+                            options: GenerationOptions(maximumResponseTokens: 16)
+                        )
+                        return response.content
+                    }
+                }
+
+                var responseCount = 0
+                for try await content in group {
+                    #expect(!content.isEmpty)
+                    responseCount += 1
+                }
+                #expect(responseCount == 2)
+            }
+        }
+
         @Test func promptLongerThanBatchSize() async throws {
             let session = LanguageModelSession(model: model)
             var options = GenerationOptions(maximumResponseTokens: 16)


### PR DESCRIPTION
Concurrent first requests could both load the same LlamaLanguageModel, allowing one load to free resources already in use by the other request. Protect the loaded-state check, loading, and publication with a dedicated lock, and make the synchronous helper explicit at both call sites.

Add a regression test using two concurrent sessions; it passes with a cached TinyLlama model, and formatting checks pass. The Llama suite has five structured-generation failures that also occur on unchanged code with the same model.

Fixes #225.
