### PR TITLE
Add tool calling to LlamaLanguageModel, including streaming

### DIFF
--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -660,7 +660,7 @@ import Foundation
             prompt: String,
             maxTokens: Int,
             options: ResolvedGenerationOptions,
-            onToken: (String) -> Void
+            onToken: (String) -> Bool
         ) throws {
             guard let model = self.model, let vocab = llama_model_get_vocab(model) else {
                 throw LlamaLanguageModelError.contextInitializationFailed
@@ -782,6 +782,176 @@ import Foundation
             }
         }
 
+        // MARK: - Tool calling
+
+        /// Prompt-side tool state for one exchange: the detected syntax, the
+        /// session's tool definitions, and the tool turns produced so far in
+        /// the current resolve-and-continue loop.
+        struct LlamaToolPromptContext {
+            let format: LlamaToolCallFormat
+            let definitions: [LlamaToolDefinition]
+            var pendingEntries: [Transcript.Entry]
+        }
+
+        private struct ToolInvocationResult {
+            let call: Transcript.ToolCall
+            let output: Transcript.ToolOutput
+        }
+
+        private enum ToolResolutionOutcome {
+            case stop(calls: [Transcript.ToolCall])
+            case invocations([ToolInvocationResult])
+        }
+
+        private static func maxToolIterationsExceededError(limit: Int) -> LanguageModelSession.GenerationError {
+            .decodingFailure(
+                .init(
+                    debugDescription:
+                        "Exceeded maximum tool iterations (\(limit)) while processing Llama tool calls."
+                )
+            )
+        }
+
+        private static func repeatedToolCallLoopError() -> LanguageModelSession.GenerationError {
+            .decodingFailure(
+                .init(
+                    debugDescription:
+                        "Detected repeated Llama tool-call signature and aborted to avoid an infinite tool loop."
+                )
+            )
+        }
+
+        private func makeToolPromptContext(for session: LanguageModelSession) throws -> LlamaToolPromptContext? {
+            guard !session.tools.isEmpty, let model = self.model else { return nil }
+            let template = llama_model_chat_template(model, nil).map { String(cString: $0) }
+            let format = LlamaToolCallFormat.detect(template: template)
+            let definitions = try session.tools.map { tool -> LlamaToolDefinition in
+                let schema = tool.parameters.withResolvedRoot() ?? tool.parameters
+                let data = try JSONEncoder().encode(schema)
+                let parameters = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                return LlamaToolDefinition(
+                    name: tool.name,
+                    description: tool.description,
+                    parameters: parameters
+                )
+            }
+            return LlamaToolPromptContext(format: format, definitions: definitions, pendingEntries: [])
+        }
+
+        private func toolOutputText(_ output: Transcript.ToolOutput) -> String {
+            var parts: [String] = []
+            for segment in output.segments {
+                switch segment {
+                case .text(let text):
+                    parts.append(text.content)
+                case .structure(let structure):
+                    parts.append(structure.content.jsonString)
+                case .image:
+                    break
+                }
+            }
+            return parts.joined(separator: "\n")
+        }
+
+        private func makeTranscriptToolCalls(
+            from parsedCalls: [LlamaParsedToolCall]
+        ) throws -> [Transcript.ToolCall] {
+            try parsedCalls.map { parsed in
+                Transcript.ToolCall(
+                    id: UUID().uuidString,
+                    toolName: parsed.name,
+                    arguments: try GeneratedContent(json: parsed.argumentsJSON)
+                )
+            }
+        }
+
+        private func resolveToolCalls(
+            _ parsedCalls: [LlamaParsedToolCall],
+            session: LanguageModelSession
+        ) async throws -> ToolResolutionOutcome {
+            if parsedCalls.isEmpty { return .invocations([]) }
+
+            var toolsByName: [String: any Tool] = [:]
+            for tool in session.tools where toolsByName[tool.name] == nil {
+                toolsByName[tool.name] = tool
+            }
+
+            let transcriptCalls = try makeTranscriptToolCalls(from: parsedCalls)
+
+            if let delegate = session.toolExecutionDelegate {
+                await delegate.didGenerateToolCalls(transcriptCalls, in: session)
+            }
+
+            var decisions: [ToolExecutionDecision] = []
+            decisions.reserveCapacity(transcriptCalls.count)
+
+            if let delegate = session.toolExecutionDelegate {
+                for call in transcriptCalls {
+                    let decision = await delegate.toolCallDecision(for: call, in: session)
+                    if case .stop = decision {
+                        return .stop(calls: transcriptCalls)
+                    }
+                    decisions.append(decision)
+                }
+            } else {
+                decisions = Array(repeating: .execute, count: transcriptCalls.count)
+            }
+
+            var results: [ToolInvocationResult] = []
+            results.reserveCapacity(transcriptCalls.count)
+
+            for (index, call) in transcriptCalls.enumerated() {
+                switch decisions[index] {
+                case .stop:
+                    return .stop(calls: transcriptCalls)
+                case .provideOutput(let segments):
+                    let output = Transcript.ToolOutput(
+                        id: call.id,
+                        toolName: call.toolName,
+                        segments: segments
+                    )
+                    if let delegate = session.toolExecutionDelegate {
+                        await delegate.didExecuteToolCall(call, output: output, in: session)
+                    }
+                    results.append(ToolInvocationResult(call: call, output: output))
+                case .execute:
+                    guard let tool = toolsByName[call.toolName] else {
+                        let message = Transcript.Segment.text(.init(content: "Tool not found: \(call.toolName)"))
+                        let output = Transcript.ToolOutput(
+                            id: call.id,
+                            toolName: call.toolName,
+                            segments: [message]
+                        )
+                        if let delegate = session.toolExecutionDelegate {
+                            await delegate.didExecuteToolCall(call, output: output, in: session)
+                        }
+                        results.append(ToolInvocationResult(call: call, output: output))
+                        continue
+                    }
+
+                    do {
+                        let segments = try await tool.makeOutputSegments(from: call.arguments)
+                        let output = Transcript.ToolOutput(
+                            id: call.id,
+                            toolName: tool.name,
+                            segments: segments
+                        )
+                        if let delegate = session.toolExecutionDelegate {
+                            await delegate.didExecuteToolCall(call, output: output, in: session)
+                        }
+                        results.append(ToolInvocationResult(call: call, output: output))
+                    } catch {
+                        if let delegate = session.toolExecutionDelegate {
+                            await delegate.didFailToolCall(call, error: error, in: session)
+                        }
+                        throw LanguageModelSession.ToolCallError(tool: tool, underlyingError: error)
+                    }
+                }
+            }
+
+            return .invocations(results)
+        }
+
         public func respond<Content>(
             within session: LanguageModelSession,
             to prompt: Prompt,
@@ -797,65 +967,143 @@ import Foundation
             let runtimeOptions = resolvedOptions(from: options)
             let structuredOptions = resolvedStructuredOptions(from: options)
 
-            var promptImages: [Data] = []
             let imageMarker = mtmdContext != nil ? String(cString: mtmd_default_marker()) : nil
-
-            let fullPrompt: String
-            if includeSchemaInPrompt, type != String.self {
-                fullPrompt = try formatPrompt(
-                    for: session,
-                    extraSystemMessage: schemaPrompt(for: type.generationSchema),
-                    assistantPrefill: runtimeOptions.assistantPrefill,
-                    imageMarker: imageMarker,
-                    images: &promptImages
-                )
-            } else {
-                fullPrompt = try formatPrompt(
-                    for: session,
-                    extraSystemMessage: nil,
-                    assistantPrefill: runtimeOptions.assistantPrefill,
-                    imageMarker: imageMarker,
-                    images: &promptImages
-                )
-            }
 
             if type == String.self {
                 let maxTokens = runtimeOptions.maximumResponseTokens ?? 100
-                let text: String
-                if promptImages.isEmpty {
+                var toolContext = try makeToolPromptContext(for: session)
+                let maxToolIterations = 8
+                var toolIteration = 0
+                var previousToolCallSignature: String?
+                var allEntries: [Transcript.Entry] = []
+                var text = ""
+
+                generationLoop: while true {
+                    var promptImages: [Data] = []
+                    let fullPrompt = try formatPrompt(
+                        for: session,
+                        extraSystemMessage: nil,
+                        assistantPrefill: runtimeOptions.assistantPrefill,
+                        imageMarker: imageMarker,
+                        images: &promptImages,
+                        toolContext: toolContext
+                    )
+
                     var accumulated = ""
-                    try generateChatText(
-                        session: session,
-                        prompt: fullPrompt,
-                        maxTokens: maxTokens,
-                        options: runtimeOptions
-                    ) { tokenText in
+                    let terminator = toolContext?.format.callTerminator
+                    let collectToken: (String) -> Bool = { tokenText in
                         accumulated += tokenText
+                        if let terminator,
+                            accumulated.suffix(terminator.count + 8).contains(terminator)
+                        {
+                            return false
+                        }
+                        return true
                     }
-                    text = accumulated
-                } else {
-                    discardCachedSessionContext()
-                    let context = try makeFreshContext(options: runtimeOptions)
-                    defer { llama_free(context) }
-                    var accumulated = ""
-                    try performMultimodalGeneration(
-                        context: context,
-                        prompt: fullPrompt,
-                        images: promptImages,
-                        maxTokens: maxTokens,
-                        options: runtimeOptions
-                    ) { tokenText in
-                        accumulated += tokenText
+
+                    if promptImages.isEmpty {
+                        try generateChatText(
+                            session: session,
+                            prompt: fullPrompt,
+                            maxTokens: maxTokens,
+                            options: runtimeOptions,
+                            onToken: collectToken
+                        )
+                    } else {
+                        discardCachedSessionContext()
+                        let context = try makeFreshContext(options: runtimeOptions)
+                        defer { llama_free(context) }
+                        try performMultimodalGeneration(
+                            context: context,
+                            prompt: fullPrompt,
+                            images: promptImages,
+                            maxTokens: maxTokens,
+                            options: runtimeOptions,
+                            onToken: collectToken
+                        )
                     }
-                    text = accumulated
+
+                    guard let format = toolContext?.format else {
+                        text = accumulated
+                        break generationLoop
+                    }
+                    let (visibleText, parsedCalls) = format.parseToolCalls(in: accumulated)
+                    if parsedCalls.isEmpty {
+                        text = visibleText
+                        break generationLoop
+                    }
+
+                    toolIteration += 1
+                    if toolIteration > maxToolIterations {
+                        let unresolved = try makeTranscriptToolCalls(from: parsedCalls)
+                        allEntries.append(.toolCalls(Transcript.ToolCalls(unresolved)))
+                        throw Self.maxToolIterationsExceededError(limit: maxToolIterations)
+                    }
+                    let signature =
+                        parsedCalls
+                        .map { "\($0.name):\($0.argumentsJSON)" }
+                        .joined(separator: "|")
+                    if signature == previousToolCallSignature {
+                        let unresolved = try makeTranscriptToolCalls(from: parsedCalls)
+                        allEntries.append(.toolCalls(Transcript.ToolCalls(unresolved)))
+                        throw Self.repeatedToolCallLoopError()
+                    }
+                    previousToolCallSignature = signature
+
+                    let resolution = try await resolveToolCalls(parsedCalls, session: session)
+                    switch resolution {
+                    case .stop(let calls):
+                        if !calls.isEmpty {
+                            allEntries.append(.toolCalls(Transcript.ToolCalls(calls)))
+                        }
+                        return LanguageModelSession.Response(
+                            content: "" as! Content,
+                            rawContent: GeneratedContent(""),
+                            transcriptEntries: ArraySlice(allEntries)
+                        )
+                    case .invocations(let invocations):
+                        guard !invocations.isEmpty else {
+                            text = visibleText
+                            break generationLoop
+                        }
+                        let callsEntry = Transcript.Entry.toolCalls(
+                            Transcript.ToolCalls(invocations.map(\.call))
+                        )
+                        allEntries.append(callsEntry)
+                        toolContext?.pendingEntries.append(callsEntry)
+                        for invocation in invocations {
+                            let outputEntry = Transcript.Entry.toolOutput(invocation.output)
+                            allEntries.append(outputEntry)
+                            toolContext?.pendingEntries.append(outputEntry)
+                        }
+                    }
                 }
 
                 return LanguageModelSession.Response(
                     content: text as! Content,
                     rawContent: GeneratedContent(text),
-                    transcriptEntries: ArraySlice([])
+                    transcriptEntries: ArraySlice(allEntries)
                 )
             } else {
+                var promptImages: [Data] = []
+                let fullPrompt: String
+                if includeSchemaInPrompt {
+                    fullPrompt = try formatPrompt(
+                        for: session,
+                        extraSystemMessage: schemaPrompt(for: type.generationSchema),
+                        assistantPrefill: runtimeOptions.assistantPrefill,
+                        imageMarker: imageMarker,
+                        images: &promptImages
+                    )
+                } else {
+                    fullPrompt = try formatPrompt(
+                        for: session,
+                        extraSystemMessage: nil,
+                        assistantPrefill: runtimeOptions.assistantPrefill,
+                        imageMarker: imageMarker,
+                        images: &promptImages
+                    )
+                }
                 // Structured output does not go through the projector yet; refuse rather
                 // than answer about an image the model never saw.
                 guard promptImages.isEmpty else {
@@ -926,7 +1174,7 @@ import Foundation
                                 images: &promptImages
                             )
 
-                            let yieldToken: (String) -> Void = { tokenText in
+                            let yieldToken: (String) -> Bool = { tokenText in
                                 accumulatedText += tokenText
 
                                 let snapshot = LanguageModelSession.ResponseStream<Content>.Snapshot(
@@ -934,6 +1182,7 @@ import Foundation
                                     rawContent: GeneratedContent(accumulatedText)
                                 )
                                 continuation.yield(snapshot)
+                                return true
                             }
 
                             if promptImages.isEmpty {
@@ -1406,7 +1655,7 @@ import Foundation
             startIndex: Int,
             maxTokens: Int,
             options: ResolvedGenerationOptions,
-            onToken: (String) -> Void
+            onToken: (String) -> Bool
         ) throws {
             guard let model = self.model else {
                 throw LlamaLanguageModelError.modelLoadFailed
@@ -1485,7 +1734,9 @@ import Foundation
 
                 // Convert token to text and yield it
                 if let tokenText = tokenToText(vocab: vocab, token: nextToken) {
-                    onToken(tokenText)
+                    guard onToken(tokenText) else {
+                        break
+                    }
                 }
 
                 // Prepare batch for next token
@@ -1518,7 +1769,7 @@ import Foundation
             images: [Data],
             maxTokens: Int,
             options: ResolvedGenerationOptions,
-            onToken: (String) -> Void
+            onToken: (String) -> Bool
         ) throws {
             guard let mtmdContext, let model = self.model,
                 let vocab = llama_model_get_vocab(model)
@@ -1634,7 +1885,9 @@ import Foundation
                 }
 
                 if let tokenText = tokenToText(vocab: vocab, token: nextToken) {
-                    onToken(tokenText)
+                    guard onToken(tokenText) else {
+                        break
+                    }
                 }
 
                 batch.n_tokens = 1
@@ -1794,7 +2047,8 @@ import Foundation
         private func formatPrompt(
             for session: LanguageModelSession,
             extraSystemMessage: String? = nil,
-            assistantPrefill: String? = nil
+            assistantPrefill: String? = nil,
+            toolContext: LlamaToolPromptContext? = nil
         ) throws -> String {
             var images: [Data] = []
             return try formatPrompt(
@@ -1802,7 +2056,8 @@ import Foundation
                 extraSystemMessage: extraSystemMessage,
                 assistantPrefill: assistantPrefill,
                 imageMarker: nil,
-                images: &images
+                images: &images,
+                toolContext: toolContext
             )
         }
 
@@ -1811,7 +2066,8 @@ import Foundation
             extraSystemMessage: String?,
             assistantPrefill: String?,
             imageMarker: String?,
-            images: inout [Data]
+            images: inout [Data],
+            toolContext: LlamaToolPromptContext? = nil
         ) throws -> String {
             guard let model = self.model else {
                 throw LlamaLanguageModelError.modelLoadFailed
@@ -1819,7 +2075,7 @@ import Foundation
 
             var messages: [(role: String, content: String)] = []
 
-            for entry in session.transcript {
+            func appendEntry(_ entry: Transcript.Entry) throws {
                 switch entry {
                 case .instructions(let instructions):
                     let text = try extractContent(
@@ -1851,8 +2107,56 @@ import Foundation
                         messages.append(("assistant", text))
                     }
 
-                default:
-                    break
+                case .toolCalls(let toolCalls):
+                    guard let toolContext else { break }
+                    let parsed = toolCalls.map {
+                        LlamaParsedToolCall(name: $0.toolName, argumentsJSON: $0.arguments.jsonString)
+                    }
+                    if let last = messages.last, last.role == "assistant" {
+                        let markup = toolContext.format.assistantText(for: parsed, precededByContent: true)
+                        messages[messages.count - 1].content += markup
+                    } else {
+                        let markup = toolContext.format.assistantText(for: parsed, precededByContent: false)
+                        messages.append(("assistant", markup))
+                    }
+
+                case .toolOutput(let output):
+                    guard let toolContext else { break }
+                    let message = toolContext.format.toolResponseMessage(
+                        toolName: output.toolName,
+                        content: toolOutputText(output)
+                    )
+                    if let last = messages.last, last.role == message.role, last.role == "user",
+                        last.content.hasSuffix("</tool_response>")
+                    {
+                        messages[messages.count - 1].content += "\n" + message.content
+                    } else {
+                        messages.append(message)
+                    }
+                }
+            }
+
+            for entry in session.transcript {
+                try appendEntry(entry)
+            }
+            if let toolContext {
+                for entry in toolContext.pendingEntries {
+                    try appendEntry(entry)
+                }
+            }
+
+            if let toolContext, !toolContext.definitions.isEmpty {
+                if let systemIndex = messages.firstIndex(where: { $0.role == "system" }) {
+                    messages[systemIndex].content = toolContext.format.systemMessage(
+                        existingText: messages[systemIndex].content,
+                        tools: toolContext.definitions
+                    )
+                } else {
+                    let systemText = toolContext.format.systemMessage(
+                        existingText: "",
+                        tools: toolContext.definitions
+                    )
+                    messages.insert(("system", systemText), at: 0)
                 }
             }
 
@@ -1929,12 +2233,38 @@ import Foundation
             assistantPrefill: String?
         ) -> String {
             var rendered = ""
-            for message in messages {
+            var openModelTurn = false
+            for (index, message) in messages.enumerated() {
+                if message.role == "tool" {
+                    rendered += message.content
+                    continue
+                }
                 let role = message.role == "assistant" ? "model" : message.role
                 let content = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
-                rendered += "<|turn>\(role)\n\(content)<turn|>\n"
+                if role == "model" && openModelTurn {
+                    rendered += content
+                } else {
+                    if openModelTurn {
+                        rendered += "<turn|>\n"
+                        openModelTurn = false
+                    }
+                    rendered += "<|turn>\(role)\n\(content)"
+                }
+                if role == "model" {
+                    let nextRole = index + 1 < messages.count ? messages[index + 1].role : nil
+                    if nextRole == "tool" || nextRole == "assistant" {
+                        openModelTurn = true
+                    } else {
+                        rendered += "<turn|>\n"
+                        openModelTurn = false
+                    }
+                } else {
+                    rendered += "<turn|>\n"
+                }
             }
-            rendered += "<|turn>model\n"
+            if !openModelTurn {
+                rendered += "<|turn>model\n"
+            }
             if let assistantPrefill, !assistantPrefill.isEmpty {
                 rendered += assistantPrefill
             }

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -790,7 +790,21 @@ import Foundation
         struct LlamaToolPromptContext {
             let format: LlamaToolCallFormat
             let definitions: [LlamaToolDefinition]
-            var pendingEntries: [Transcript.Entry]
+            var pendingEntries: [Transcript.Entry] = []
+
+            init(format: LlamaToolCallFormat, tools: [any Tool]) throws {
+                self.format = format
+                self.definitions = try tools.filter(\.includesSchemaInInstructions).map { tool in
+                    let schema = tool.parameters.withResolvedRoot() ?? tool.parameters
+                    let data = try JSONEncoder().encode(schema)
+                    let parameters = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                    return LlamaToolDefinition(
+                        name: tool.name,
+                        description: tool.description,
+                        parameters: parameters
+                    )
+                }
+            }
         }
 
         private struct ToolInvocationResult {
@@ -829,18 +843,7 @@ import Foundation
 
         private func makeToolPromptContext(for session: LanguageModelSession) throws -> LlamaToolPromptContext? {
             guard !session.tools.isEmpty, self.model != nil else { return nil }
-            let format = currentToolCallFormat()
-            let definitions = try session.tools.map { tool -> LlamaToolDefinition in
-                let schema = tool.parameters.withResolvedRoot() ?? tool.parameters
-                let data = try JSONEncoder().encode(schema)
-                let parameters = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-                return LlamaToolDefinition(
-                    name: tool.name,
-                    description: tool.description,
-                    parameters: parameters
-                )
-            }
-            return LlamaToolPromptContext(format: format, definitions: definitions, pendingEntries: [])
+            return try LlamaToolPromptContext(format: currentToolCallFormat(), tools: session.tools)
         }
 
         private func toolOutputText(_ output: Transcript.ToolOutput) -> String {

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -1039,8 +1039,10 @@ import Foundation
                         break generationLoop
                     }
                     let (visibleText, parsedCalls) = format.parseToolCalls(in: accumulated)
+                    // Keep the text from every round, as the streaming path does,
+                    // so a preamble before a tool call is not lost.
+                    text += visibleText
                     if parsedCalls.isEmpty {
-                        text = visibleText
                         break generationLoop
                     }
 
@@ -1074,7 +1076,6 @@ import Foundation
                         )
                     case .invocations(let invocations):
                         guard !invocations.isEmpty else {
-                            text = visibleText
                             break generationLoop
                         }
                         let callsEntry = Transcript.Entry.toolCalls(
@@ -1253,7 +1254,8 @@ import Foundation
 
                                 let roundVisible = outputFormat.streamingVisibleText(
                                     in: roundRaw,
-                                    withholdToolCalls: withholdToolCalls
+                                    withholdToolCalls: withholdToolCalls,
+                                    holdPartialMarkers: false
                                 )
 
                                 guard let format = toolContext?.format else {

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -821,10 +821,15 @@ import Foundation
             )
         }
 
-        private func makeToolPromptContext(for session: LanguageModelSession) throws -> LlamaToolPromptContext? {
-            guard !session.tools.isEmpty, let model = self.model else { return nil }
+        private func currentToolCallFormat() -> LlamaToolCallFormat {
+            guard let model = self.model else { return .hermesJSON }
             let template = llama_model_chat_template(model, nil).map { String(cString: $0) }
-            let format = LlamaToolCallFormat.detect(template: template)
+            return LlamaToolCallFormat.detect(template: template)
+        }
+
+        private func makeToolPromptContext(for session: LanguageModelSession) throws -> LlamaToolPromptContext? {
+            guard !session.tools.isEmpty, self.model != nil else { return nil }
+            let format = currentToolCallFormat()
             let definitions = try session.tools.map { tool -> LlamaToolDefinition in
                 let schema = tool.parameters.withResolvedRoot() ?? tool.parameters
                 let data = try JSONEncoder().encode(schema)
@@ -971,6 +976,7 @@ import Foundation
 
             if type == String.self {
                 let maxTokens = runtimeOptions.maximumResponseTokens ?? 100
+                let outputFormat = currentToolCallFormat()
                 var toolContext = try makeToolPromptContext(for: session)
                 let maxToolIterations = 8
                 var toolIteration = 0
@@ -1024,7 +1030,12 @@ import Foundation
                     }
 
                     guard let format = toolContext?.format else {
-                        text = accumulated
+                        if outputFormat == .gemma {
+                            text = LlamaToolCallFormat.stripGemmaThoughtChannels(from: accumulated)
+                                .trimmingCharacters(in: .whitespacesAndNewlines)
+                        } else {
+                            text = accumulated
+                        }
                         break generationLoop
                     }
                     let (visibleText, parsedCalls) = format.parseToolCalls(in: accumulated)
@@ -1161,52 +1172,149 @@ import Foundation
 
                             let runtimeOptions = resolvedOptions(from: options)
                             let maxTokens = runtimeOptions.maximumResponseTokens ?? 100
-
-                            var accumulatedText = ""
-                            var promptImages: [Data] = []
+                            let outputFormat = self.currentToolCallFormat()
+                            var toolContext = try self.makeToolPromptContext(for: session)
+                            let maxToolIterations = 8
+                            var toolIteration = 0
+                            var previousToolCallSignature: String?
+                            var accumulatedEntries: [Transcript.Entry] = []
+                            var emittedBase = ""
+                            var lastYieldedText: String?
                             let imageMarker =
                                 self.mtmdContext != nil ? String(cString: mtmd_default_marker()) : nil
-                            let fullPrompt = try self.formatPrompt(
-                                for: session,
-                                extraSystemMessage: nil,
-                                assistantPrefill: runtimeOptions.assistantPrefill,
-                                imageMarker: imageMarker,
-                                images: &promptImages
-                            )
 
-                            let yieldToken: (String) -> Bool = { tokenText in
-                                accumulatedText += tokenText
-
+                            func yieldSnapshot(_ text: String) {
+                                lastYieldedText = text
                                 let snapshot = LanguageModelSession.ResponseStream<Content>.Snapshot(
-                                    content: (accumulatedText as! Content).asPartiallyGenerated(),
-                                    rawContent: GeneratedContent(accumulatedText)
+                                    content: (text as! Content).asPartiallyGenerated(),
+                                    rawContent: GeneratedContent(text),
+                                    transcriptEntries: ArraySlice(accumulatedEntries)
                                 )
                                 continuation.yield(snapshot)
-                                return true
                             }
 
-                            if promptImages.isEmpty {
-                                try self.generateChatText(
-                                    session: session,
-                                    prompt: fullPrompt,
-                                    maxTokens: maxTokens,
-                                    options: runtimeOptions,
-                                    onToken: yieldToken
+                            generationLoop: while true {
+                                var promptImages: [Data] = []
+                                let fullPrompt = try self.formatPrompt(
+                                    for: session,
+                                    extraSystemMessage: nil,
+                                    assistantPrefill: runtimeOptions.assistantPrefill,
+                                    imageMarker: imageMarker,
+                                    images: &promptImages,
+                                    toolContext: toolContext
                                 )
-                            } else {
-                                self.discardCachedSessionContext()
-                                let context = try self.makeFreshContext(options: runtimeOptions)
-                                defer { llama_free(context) }
-                                try self.performMultimodalGeneration(
-                                    context: context,
-                                    prompt: fullPrompt,
-                                    images: promptImages,
-                                    maxTokens: maxTokens,
-                                    options: runtimeOptions,
-                                    onToken: yieldToken
+
+                                var roundRaw = ""
+                                let terminator = toolContext?.format.callTerminator
+                                let withholdToolCalls = toolContext != nil
+                                let collectToken: (String) -> Bool = { tokenText in
+                                    roundRaw += tokenText
+                                    let visible = outputFormat.streamingVisibleText(
+                                        in: roundRaw,
+                                        withholdToolCalls: withholdToolCalls
+                                    )
+                                    let total = emittedBase + visible
+                                    if !total.isEmpty, total != lastYieldedText {
+                                        yieldSnapshot(total)
+                                    }
+                                    if let terminator,
+                                        roundRaw.suffix(terminator.count + 8).contains(terminator)
+                                    {
+                                        return false
+                                    }
+                                    return true
+                                }
+
+                                if promptImages.isEmpty {
+                                    try self.generateChatText(
+                                        session: session,
+                                        prompt: fullPrompt,
+                                        maxTokens: maxTokens,
+                                        options: runtimeOptions,
+                                        onToken: collectToken
+                                    )
+                                } else {
+                                    self.discardCachedSessionContext()
+                                    let context = try self.makeFreshContext(options: runtimeOptions)
+                                    defer { llama_free(context) }
+                                    try self.performMultimodalGeneration(
+                                        context: context,
+                                        prompt: fullPrompt,
+                                        images: promptImages,
+                                        maxTokens: maxTokens,
+                                        options: runtimeOptions,
+                                        onToken: collectToken
+                                    )
+                                }
+
+                                if Task.isCancelled {
+                                    break generationLoop
+                                }
+
+                                let roundVisible = outputFormat.streamingVisibleText(
+                                    in: roundRaw,
+                                    withholdToolCalls: withholdToolCalls
                                 )
+
+                                guard let format = toolContext?.format else {
+                                    emittedBase += roundVisible
+                                    break generationLoop
+                                }
+                                let (_, parsedCalls) = format.parseToolCalls(in: roundRaw)
+                                if parsedCalls.isEmpty {
+                                    emittedBase += roundVisible
+                                    break generationLoop
+                                }
+
+                                toolIteration += 1
+                                if toolIteration > maxToolIterations {
+                                    let unresolved = try self.makeTranscriptToolCalls(from: parsedCalls)
+                                    accumulatedEntries.append(.toolCalls(Transcript.ToolCalls(unresolved)))
+                                    throw Self.maxToolIterationsExceededError(limit: maxToolIterations)
+                                }
+                                let signature =
+                                    parsedCalls
+                                    .map { "\($0.name):\($0.argumentsJSON)" }
+                                    .joined(separator: "|")
+                                if signature == previousToolCallSignature {
+                                    let unresolved = try self.makeTranscriptToolCalls(from: parsedCalls)
+                                    accumulatedEntries.append(.toolCalls(Transcript.ToolCalls(unresolved)))
+                                    throw Self.repeatedToolCallLoopError()
+                                }
+                                previousToolCallSignature = signature
+
+                                let resolution = try await self.resolveToolCalls(parsedCalls, session: session)
+                                switch resolution {
+                                case .stop(let calls):
+                                    emittedBase += roundVisible
+                                    if !calls.isEmpty {
+                                        accumulatedEntries.append(.toolCalls(Transcript.ToolCalls(calls)))
+                                        yieldSnapshot(emittedBase)
+                                    }
+                                    break generationLoop
+                                case .invocations(let invocations):
+                                    guard !invocations.isEmpty else {
+                                        emittedBase += roundVisible
+                                        break generationLoop
+                                    }
+                                    let callsEntry = Transcript.Entry.toolCalls(
+                                        Transcript.ToolCalls(invocations.map(\.call))
+                                    )
+                                    accumulatedEntries.append(callsEntry)
+                                    toolContext?.pendingEntries.append(callsEntry)
+                                    for invocation in invocations {
+                                        let outputEntry = Transcript.Entry.toolOutput(invocation.output)
+                                        accumulatedEntries.append(outputEntry)
+                                        toolContext?.pendingEntries.append(outputEntry)
+                                    }
+                                    emittedBase += roundVisible
+                                    yieldSnapshot(emittedBase)
+                                }
                             }
 
+                            if emittedBase != lastYieldedText {
+                                yieldSnapshot(emittedBase)
+                            }
                             continuation.finish()
                         } catch {
                             continuation.finish(throwing: error)

--- a/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
@@ -1,0 +1,668 @@
+import Foundation
+
+/// The tool-calling syntax a GGUF model was trained on, detected from its
+/// embedded chat template.
+///
+/// `llama_chat_apply_template` renders chat messages but has no parameter for
+/// tool definitions, so tool support is implemented at this layer: definitions
+/// are rendered into the system prompt, past tool turns are replayed in the
+/// model's native markup, and calls are parsed back out of generated text.
+enum LlamaToolCallFormat: Sendable, Equatable {
+    /// Hermes-style JSON calls, used by Qwen 2.5/3 and many community fine-tunes:
+    /// `<tool_call>{"name": ..., "arguments": {...}}</tool_call>`.
+    case hermesJSON
+
+    /// Qwen 3.5 XML calls:
+    /// `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>`.
+    case qwenXML
+
+    /// Gemma 4 canonical calls:
+    /// `<|tool_call>call:name{key:value}<tool_call|>`, with `<|"|>`-quoted strings.
+    case gemma
+
+    /// Detects the format from a model's embedded chat template text.
+    /// Unrecognized templates fall back to the Hermes JSON convention.
+    static func detect(template: String?) -> LlamaToolCallFormat {
+        guard let template else { return .hermesJSON }
+        if template.contains("<|turn>") { return .gemma }
+        if template.contains("<function=") { return .qwenXML }
+        return .hermesJSON
+    }
+
+    /// The marker that ends a complete tool-call block in generated text.
+    ///
+    /// Generation stops at the first terminator, so each round of a tool
+    /// exchange carries exactly one call. Models that want several calls
+    /// issue them across consecutive rounds, each with its own output.
+    var callTerminator: String {
+        switch self {
+        case .hermesJSON, .qwenXML: return "</tool_call>"
+        case .gemma: return "<tool_call|>"
+        }
+    }
+}
+
+/// A tool definition rendered into the system prompt.
+struct LlamaToolDefinition {
+    let name: String
+    let description: String
+    let parameters: [String: Any]?
+}
+
+/// A tool call parsed out of generated text.
+struct LlamaParsedToolCall: Equatable {
+    let name: String
+    let argumentsJSON: String
+}
+
+// MARK: - System prompt rendering
+
+extension LlamaToolCallFormat {
+    /// Renders the tool section of the system prompt and merges it with any
+    /// existing system text, following each template's own ordering.
+    func systemMessage(existingText: String, tools: [LlamaToolDefinition]) -> String {
+        guard !tools.isEmpty else { return existingText }
+        switch self {
+        case .hermesJSON:
+            let block = hermesToolsBlock(tools: tools)
+            return existingText.isEmpty ? block : existingText + "\n\n" + block
+        case .qwenXML:
+            let block = qwenXMLToolsBlock(tools: tools)
+            return existingText.isEmpty ? block : block + "\n\n" + existingText
+        case .gemma:
+            let declarations = tools.map { "<|tool>" + gemmaDeclaration(for: $0) + "<tool|>" }.joined()
+            return existingText + declarations
+        }
+    }
+
+    private func toolSpecJSON(_ tool: LlamaToolDefinition) -> String {
+        var function: [String: Any] = [
+            "name": tool.name,
+            "description": tool.description,
+        ]
+        if let parameters = tool.parameters {
+            function["parameters"] = parameters
+        }
+        let spec: [String: Any] = ["type": "function", "function": function]
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: spec, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return json
+    }
+
+    private func hermesToolsBlock(tools: [LlamaToolDefinition]) -> String {
+        var block = "# Tools\n\n"
+        block += "You may call one or more functions to assist with the user query.\n\n"
+        block += "You are provided with function signatures within <tools></tools> XML tags:\n<tools>"
+        for tool in tools {
+            block += "\n" + toolSpecJSON(tool)
+        }
+        block += "\n</tools>\n\n"
+        block +=
+            "For each function call, return a json object with function name and arguments within "
+            + "<tool_call></tool_call> XML tags:\n<tool_call>\n"
+            + "{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>"
+        return block
+    }
+
+    private func qwenXMLToolsBlock(tools: [LlamaToolDefinition]) -> String {
+        var block = "# Tools\n\n"
+        block += "You have access to the following functions:\n\n<tools>"
+        for tool in tools {
+            block += "\n" + toolSpecJSON(tool)
+        }
+        block += "\n</tools>\n\n"
+        block += "If you choose to call a function ONLY reply in the following format with NO suffix:\n\n"
+        block += "<tool_call>\n<function=example_function_name>\n"
+        block += "<parameter=example_parameter_1>\nvalue_1\n</parameter>\n"
+        block += "<parameter=example_parameter_2>\nThis is the value for the second parameter\n"
+        block += "that can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n"
+        block += "<IMPORTANT>\nReminder:\n"
+        block +=
+            "- Function calls MUST follow the specified format: an inner <function=...></function> "
+            + "block must be nested within <tool_call></tool_call> XML tags\n"
+        block += "- Required parameters MUST be specified\n"
+        block +=
+            "- You may provide optional reasoning for your function call in natural language "
+            + "BEFORE the function call, but NOT after\n"
+        block +=
+            "- If there is no function call available, answer the question like normal with your "
+            + "current knowledge and do not tell the user about function calls\n"
+        block += "</IMPORTANT>"
+        return block
+    }
+}
+
+// MARK: - Gemma declaration and argument notation
+
+extension LlamaToolCallFormat {
+    /// Renders one Gemma 4 function declaration:
+    /// `declaration:name{description:<|"|>...<|"|>,parameters:{...}}`.
+    /// Types are uppercased and strings are quoted with the `<|"|>` token, per
+    /// the canonical template's `format_function_declaration` macro.
+    fileprivate func gemmaDeclaration(for tool: LlamaToolDefinition) -> String {
+        var rendered = "declaration:\(tool.name){description:\(gemmaQuote(tool.description))"
+        if let parameters = tool.parameters {
+            rendered += ",parameters:{"
+            var parts: [String] = []
+            if let properties = parameters["properties"] as? [String: Any], !properties.isEmpty {
+                parts.append("properties:{" + gemmaProperties(properties) + "}")
+            }
+            if let required = parameters["required"] as? [Any], !required.isEmpty {
+                let items = required.map { gemmaQuote("\($0)") }.joined(separator: ",")
+                parts.append("required:[\(items)]")
+            }
+            if let type = parameters["type"] as? String {
+                parts.append("type:\(gemmaQuote(type.uppercased()))")
+            }
+            rendered += parts.joined(separator: ",") + "}"
+        }
+        rendered += "}"
+        return rendered
+    }
+
+    private func gemmaProperties(_ properties: [String: Any]) -> String {
+        var parts: [String] = []
+        for key in properties.keys.sorted() {
+            guard let value = properties[key] as? [String: Any] else { continue }
+            var fields: [String] = []
+            if let description = value["description"] as? String {
+                fields.append("description:\(gemmaQuote(description))")
+            }
+            let type = (value["type"] as? String)?.uppercased() ?? "STRING"
+            if type == "STRING", let enumValues = value["enum"] as? [Any] {
+                let items = enumValues.map { gemmaArgument($0) }.joined(separator: ",")
+                fields.append("enum:[\(items)]")
+            }
+            if type == "ARRAY", let items = value["items"] as? [String: Any], !items.isEmpty {
+                var itemFields: [String] = []
+                for itemKey in items.keys.sorted() {
+                    guard let itemValue = items[itemKey] else { continue }
+                    if itemKey == "type", let itemType = itemValue as? String {
+                        itemFields.append("type:\(gemmaQuote(itemType.uppercased()))")
+                    } else if itemKey == "properties", let nested = itemValue as? [String: Any] {
+                        itemFields.append("properties:{" + gemmaProperties(nested) + "}")
+                    } else if itemKey == "required", let required = itemValue as? [Any] {
+                        let names = required.map { gemmaQuote("\($0)") }.joined(separator: ",")
+                        itemFields.append("required:[\(names)]")
+                    } else {
+                        itemFields.append("\(itemKey):\(gemmaArgument(itemValue))")
+                    }
+                }
+                fields.append("items:{" + itemFields.joined(separator: ",") + "}")
+            }
+            if type == "OBJECT", let nested = value["properties"] as? [String: Any] {
+                fields.append("properties:{" + gemmaProperties(nested) + "}")
+                if let required = value["required"] as? [Any], !required.isEmpty {
+                    let names = required.map { gemmaQuote("\($0)") }.joined(separator: ",")
+                    fields.append("required:[\(names)]")
+                }
+            }
+            fields.append("type:\(gemmaQuote(type))")
+            parts.append("\(key):{" + fields.joined(separator: ",") + "}")
+        }
+        return parts.joined(separator: ",")
+    }
+
+    fileprivate func gemmaQuote(_ string: String) -> String {
+        "<|\"|>\(string)<|\"|>"
+    }
+
+    /// Renders one JSON value in Gemma 4 argument notation: unquoted keys,
+    /// `<|"|>`-quoted strings, and dictionary keys in sorted order.
+    fileprivate func gemmaArgument(_ value: Any) -> String {
+        switch value {
+        case is NSNull:
+            return "null"
+        case let string as String:
+            return gemmaQuote(string)
+        case let number as NSNumber:
+            if isBooleanNumber(number) {
+                return number.boolValue ? "true" : "false"
+            }
+            if number.doubleValue == number.doubleValue.rounded(),
+                number.doubleValue.magnitude < 1e15,
+                !"\(number)".contains(".")
+            {
+                return "\(number.int64Value)"
+            }
+            return "\(number)"
+        case let dictionary as [String: Any]:
+            let fields = dictionary.keys.sorted().map { "\($0):\(gemmaArgument(dictionary[$0]!))" }
+            return "{" + fields.joined(separator: ",") + "}"
+        case let array as [Any]:
+            return "[" + array.map { gemmaArgument($0) }.joined(separator: ",") + "]"
+        default:
+            return gemmaQuote("\(value)")
+        }
+    }
+
+    /// Renders a JSON object string as Gemma 4 call arguments (the text between
+    /// the braces of `call:name{...}`).
+    fileprivate func gemmaArgumentsBody(fromJSON json: String) -> String {
+        guard
+            let data = json.data(using: .utf8),
+            let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else {
+            return ""
+        }
+        return object.keys.sorted().map { "\($0):\(gemmaArgument(object[$0]!))" }.joined(separator: ",")
+    }
+}
+
+// MARK: - Transcript replay rendering
+
+extension LlamaToolCallFormat {
+    /// Renders past tool calls as the assistant-message text the model
+    /// originally produced, so multi-turn history replays faithfully.
+    func assistantText(for calls: [LlamaParsedToolCall], precededByContent: Bool) -> String {
+        var parts: [String] = []
+        for call in calls {
+            switch self {
+            case .hermesJSON:
+                parts.append(
+                    "<tool_call>\n{\"name\": \"\(call.name)\", \"arguments\": \(call.argumentsJSON)}\n</tool_call>"
+                )
+            case .qwenXML:
+                var block = "<tool_call>\n<function=\(call.name)>\n"
+                if let data = call.argumentsJSON.data(using: .utf8),
+                    let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+                {
+                    for key in object.keys.sorted() {
+                        block += "<parameter=\(key)>\n\(qwenXMLParameterValue(object[key]!))\n</parameter>\n"
+                    }
+                }
+                block += "</function>\n</tool_call>"
+                parts.append(block)
+            case .gemma:
+                parts.append(
+                    "<|tool_call>call:\(call.name){\(gemmaArgumentsBody(fromJSON: call.argumentsJSON))}<tool_call|>"
+                )
+            }
+        }
+        let joined = parts.joined(separator: "\n")
+        if precededByContent && self != .gemma {
+            return "\n" + joined
+        }
+        return joined
+    }
+
+    private func qwenXMLParameterValue(_ value: Any) -> String {
+        if let string = value as? String { return string }
+        if let number = value as? NSNumber {
+            if isBooleanNumber(number) {
+                return number.boolValue ? "true" : "false"
+            }
+            return "\(number)"
+        }
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        else {
+            return "\(value)"
+        }
+        return json
+    }
+
+    /// Renders one tool output as the message that carries it back to the model.
+    /// Hermes and Qwen XML formats deliver results inside a user turn; Gemma 4
+    /// continues the open model turn with a `<|tool_response>` block.
+    func toolResponseMessage(toolName: String, content: String) -> (role: String, content: String) {
+        switch self {
+        case .hermesJSON, .qwenXML:
+            return ("user", "<tool_response>\n\(content)\n</tool_response>")
+        case .gemma:
+            let body: String
+            if let data = content.data(using: .utf8),
+                let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            {
+                body = object.keys.sorted().map { "\($0):\(gemmaArgument(object[$0]!))" }.joined(separator: ",")
+            } else {
+                body = "value:\(gemmaArgument(content))"
+            }
+            return ("tool", "<|tool_response>response:\(toolName){\(body)}<tool_response|>")
+        }
+    }
+}
+
+// MARK: - Parsing generated text
+
+extension LlamaToolCallFormat {
+    /// Splits generated text into the visible response and any tool calls,
+    /// removing the call markup from the visible portion.
+    func parseToolCalls(in text: String) -> (visibleText: String, calls: [LlamaParsedToolCall]) {
+        switch self {
+        case .hermesJSON:
+            return parseMarkedBlocks(in: text, start: "<tool_call>", end: "</tool_call>") { body in
+                parseHermesCall(body)
+            }
+        case .qwenXML:
+            return parseMarkedBlocks(in: text, start: "<tool_call>", end: "</tool_call>") { body in
+                parseQwenXMLCall(body)
+            }
+        case .gemma:
+            return parseGemmaCalls(in: text)
+        }
+    }
+
+    private func parseMarkedBlocks(
+        in text: String,
+        start: String,
+        end: String,
+        parse: (String) -> LlamaParsedToolCall?
+    ) -> (String, [LlamaParsedToolCall]) {
+        var visible = ""
+        var calls: [LlamaParsedToolCall] = []
+        var remainder = Substring(text)
+        while let startRange = remainder.range(of: start) {
+            visible += remainder[..<startRange.lowerBound]
+            let afterStart = remainder[startRange.upperBound...]
+            guard let endRange = afterStart.range(of: end) else {
+                visible += remainder[startRange.lowerBound...]
+                remainder = Substring("")
+                break
+            }
+            let body = String(afterStart[..<endRange.lowerBound])
+            if let call = parse(body) {
+                calls.append(call)
+            }
+            remainder = afterStart[endRange.upperBound...]
+        }
+        visible += remainder
+        return (visible.trimmingCharacters(in: .whitespacesAndNewlines), calls)
+    }
+
+    private func parseHermesCall(_ body: String) -> LlamaParsedToolCall? {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            let data = trimmed.data(using: .utf8),
+            let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            let name = object["name"] as? String
+        else {
+            return nil
+        }
+        var argumentsJSON = "{}"
+        if let arguments = object["arguments"] {
+            if let nested = arguments as? String {
+                argumentsJSON = nested
+            } else if let argumentsData = try? JSONSerialization.data(
+                withJSONObject: arguments,
+                options: [.sortedKeys]
+            ), let json = String(data: argumentsData, encoding: .utf8) {
+                argumentsJSON = json
+            }
+        }
+        return LlamaParsedToolCall(name: name, argumentsJSON: argumentsJSON)
+    }
+
+    private func parseQwenXMLCall(_ body: String) -> LlamaParsedToolCall? {
+        guard let nameStart = body.range(of: "<function=") else { return nil }
+        let afterName = body[nameStart.upperBound...]
+        guard let nameEnd = afterName.firstIndex(of: ">") else { return nil }
+        let name = String(afterName[..<nameEnd])
+        guard !name.isEmpty else { return nil }
+
+        var arguments: [String: Any] = [:]
+        var remainder = afterName[afterName.index(after: nameEnd)...]
+        while let paramStart = remainder.range(of: "<parameter=") {
+            let afterParam = remainder[paramStart.upperBound...]
+            guard let keyEnd = afterParam.firstIndex(of: ">") else { break }
+            let key = String(afterParam[..<keyEnd])
+            let valueStart = afterParam.index(after: keyEnd)
+            guard let paramEnd = afterParam[valueStart...].range(of: "</parameter>") else { break }
+            var value = String(afterParam[valueStart ..< paramEnd.lowerBound])
+            if value.hasPrefix("\n") { value.removeFirst() }
+            if value.hasSuffix("\n") { value.removeLast() }
+            arguments[key] = qwenXMLDecodedValue(value)
+            remainder = afterParam[paramEnd.upperBound...]
+        }
+
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: arguments, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        return LlamaParsedToolCall(name: name, argumentsJSON: json)
+    }
+
+    /// The XML format writes objects and arrays as JSON but scalars as raw
+    /// text, so structured values are decoded and everything else stays a
+    /// string.
+    private func qwenXMLDecodedValue(_ raw: String) -> Any {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else { return raw }
+        guard
+            let data = trimmed.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        else {
+            return raw
+        }
+        return object
+    }
+
+    private func parseGemmaCalls(in text: String) -> (String, [LlamaParsedToolCall]) {
+        var visible = ""
+        var calls: [LlamaParsedToolCall] = []
+        var remainder = Substring(text)
+        while let startRange = remainder.range(of: "<|tool_call>call:") {
+            visible += remainder[..<startRange.lowerBound]
+            let afterStart = remainder[startRange.upperBound...]
+            guard let braceIndex = afterStart.firstIndex(of: "{") else {
+                visible += remainder[startRange.lowerBound...]
+                remainder = Substring("")
+                break
+            }
+            let name = String(afterStart[..<braceIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let bodyStart = afterStart.index(after: braceIndex)
+            guard let bodyEnd = gemmaBalancedBodyEnd(in: afterStart, from: bodyStart) else {
+                visible += remainder[startRange.lowerBound...]
+                remainder = Substring("")
+                break
+            }
+            let body = String(afterStart[bodyStart ..< bodyEnd])
+            var rest = afterStart[afterStart.index(after: bodyEnd)...]
+            if let terminator = rest.range(of: "<tool_call|>"),
+                rest[..<terminator.lowerBound].allSatisfy({ $0.isWhitespace })
+            {
+                rest = rest[terminator.upperBound...]
+            }
+            var parser = LlamaGemmaArgumentParser(body)
+            if !name.isEmpty, let argumentsJSON = parser.parseObjectJSON() {
+                calls.append(LlamaParsedToolCall(name: name, argumentsJSON: argumentsJSON))
+            }
+            remainder = rest
+        }
+        visible += remainder
+        return (visible.trimmingCharacters(in: .whitespacesAndNewlines), calls)
+    }
+
+    /// Finds the closing brace of a Gemma call body, skipping braces inside
+    /// `<|"|>`-quoted strings and counting nested structures.
+    private func gemmaBalancedBodyEnd(
+        in text: Substring,
+        from start: Substring.Index
+    ) -> Substring.Index? {
+        var depth = 0
+        var index = start
+        while index < text.endIndex {
+            if text[index...].hasPrefix("<|\"|>") {
+                let afterQuote = text.index(index, offsetBy: 5)
+                guard let closeQuote = text[afterQuote...].range(of: "<|\"|>") else { return nil }
+                index = closeQuote.upperBound
+                continue
+            }
+            let character = text[index]
+            if character == "{" || character == "[" {
+                depth += 1
+            } else if character == "]" {
+                depth -= 1
+            } else if character == "}" {
+                if depth == 0 { return index }
+                depth -= 1
+            }
+            index = text.index(after: index)
+        }
+        return nil
+    }
+}
+
+/// Parses Gemma 4 argument notation into canonical JSON: unquoted keys,
+/// `<|"|>`-quoted strings, nested objects and arrays, and bare
+/// number/boolean/null literals.
+struct LlamaGemmaArgumentParser {
+    private let characters: [Character]
+    private var index = 0
+
+    init(_ text: String) {
+        self.characters = Array(text)
+    }
+
+    /// Parses the full input as an object body (`key:value,...`) and returns
+    /// it as a JSON object string, or `nil` if the input is malformed.
+    mutating func parseObjectJSON() -> String? {
+        guard let object = parseObjectBody(terminators: []) else { return nil }
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        skipWhitespace()
+        guard index >= characters.count else { return nil }
+        return json
+    }
+
+    private mutating func parseObjectBody(terminators: Set<Character>) -> [String: Any]? {
+        var object: [String: Any] = [:]
+        skipWhitespace()
+        while index < characters.count, !terminators.contains(characters[index]) {
+            guard let key = parseKey() else { return nil }
+            guard consume(":") else { return nil }
+            guard let value = parseValue() else { return nil }
+            object[key] = value
+            skipWhitespace()
+            if index < characters.count, characters[index] == "," {
+                index += 1
+                skipWhitespace()
+            } else {
+                break
+            }
+        }
+        return object
+    }
+
+    private mutating func parseKey() -> String? {
+        skipWhitespace()
+        if let quoted = parseQuotedString() { return quoted }
+        var key = ""
+        while index < characters.count {
+            let character = characters[index]
+            if character == ":" || character == "," || character == "}" { break }
+            key.append(character)
+            index += 1
+        }
+        let trimmed = key.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private mutating func parseValue() -> Any? {
+        skipWhitespace()
+        if let string = parseQuotedString() { return string }
+        guard index < characters.count else { return nil }
+        switch characters[index] {
+        case "{":
+            index += 1
+            guard let object = parseObjectBody(terminators: ["}"]) else { return nil }
+            guard consume("}") else { return nil }
+            return object
+        case "[":
+            index += 1
+            var array: [Any] = []
+            skipWhitespace()
+            while index < characters.count, characters[index] != "]" {
+                guard let element = parseValue() else { return nil }
+                array.append(element)
+                skipWhitespace()
+                if index < characters.count, characters[index] == "," {
+                    index += 1
+                    skipWhitespace()
+                }
+            }
+            guard consume("]") else { return nil }
+            return array
+        default:
+            var literal = ""
+            while index < characters.count {
+                let character = characters[index]
+                if character == "," || character == "}" || character == "]" { break }
+                literal.append(character)
+                index += 1
+            }
+            let trimmed = literal.trimmingCharacters(in: .whitespaces)
+            switch trimmed {
+            case "true": return true
+            case "false": return false
+            case "null": return NSNull()
+            default:
+                if let integer = Int64(trimmed) { return integer }
+                if let double = Double(trimmed) { return double }
+                return trimmed
+            }
+        }
+    }
+
+    private mutating func parseQuotedString() -> String? {
+        guard remainingHasPrefix("<|\"|>") else { return nil }
+        index += 5
+        var value = ""
+        while index < characters.count {
+            if remainingHasPrefix("<|\"|>") {
+                index += 5
+                return value
+            }
+            value.append(characters[index])
+            index += 1
+        }
+        return nil
+    }
+
+    private func remainingHasPrefix(_ prefix: String) -> Bool {
+        let prefixCharacters = Array(prefix)
+        guard index + prefixCharacters.count <= characters.count else { return false }
+        for offset in 0 ..< prefixCharacters.count
+        where characters[index + offset] != prefixCharacters[offset] {
+            return false
+        }
+        return true
+    }
+
+    private mutating func skipWhitespace() {
+        while index < characters.count, characters[index].isWhitespace {
+            index += 1
+        }
+    }
+
+    private mutating func consume(_ character: Character) -> Bool {
+        skipWhitespace()
+        guard index < characters.count, characters[index] == character else { return false }
+        index += 1
+        return true
+    }
+}
+
+/// Whether an `NSNumber` produced by JSON decoding holds a boolean.
+///
+/// Core Foundation type identity is the exact check on Darwin. swift-corelibs-foundation
+/// has no `CFBoolean`, so other platforms fall back to the encoded Objective-C type,
+/// which JSON decoding sets to `c` only for booleans.
+func isBooleanNumber(_ number: NSNumber) -> Bool {
+    #if canImport(Darwin)
+        return CFGetTypeID(number) == CFBooleanGetTypeID()
+    #else
+        return String(cString: number.objCType) == "c"
+    #endif
+}

--- a/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
@@ -40,6 +40,94 @@ enum LlamaToolCallFormat: Sendable, Equatable {
         case .gemma: return "<tool_call|>"
         }
     }
+
+    /// The marker that starts a tool-call block in generated text.
+    var callStartMarker: String {
+        switch self {
+        case .hermesJSON, .qwenXML: return "<tool_call>"
+        case .gemma: return "<|tool_call>"
+        }
+    }
+
+    /// Markers that open a Gemma 4 thought channel. The canonical template
+    /// writes `<|channel>`, but deployed quantizations have been observed
+    /// emitting `<|channel|>`, so both spellings are recognized.
+    static let gemmaChannelOpenMarkers = ["<|channel>", "<|channel|>"]
+
+    /// The marker that closes a Gemma 4 thought channel.
+    static let gemmaChannelCloseMarker = "<channel|>"
+
+    /// Removes Gemma 4 thought-channel spans from generated text. Thinking is
+    /// opt-in via `<|think|>`, but the model volunteers thought channels
+    /// anyway; the canonical template ships a `strip_thinking` macro for the
+    /// same reason. A span left unclosed at the end of the text is removed
+    /// through the end.
+    static func stripGemmaThoughtChannels(from text: String) -> String {
+        var result = ""
+        var remainder = Substring(text)
+        while let open = earliestRange(of: gemmaChannelOpenMarkers, in: remainder) {
+            result += remainder[..<open.lowerBound]
+            let afterOpen = remainder[open.upperBound...]
+            if let close = afterOpen.range(of: gemmaChannelCloseMarker) {
+                remainder = afterOpen[close.upperBound...]
+            } else {
+                remainder = Substring("")
+            }
+        }
+        result += remainder
+        return result
+    }
+
+    private static func earliestRange(
+        of markers: [String],
+        in text: Substring
+    ) -> Range<Substring.Index>? {
+        var earliest: Range<Substring.Index>?
+        for marker in markers {
+            if let range = text.range(of: marker),
+                earliest == nil || range.lowerBound < earliest!.lowerBound
+            {
+                earliest = range
+            }
+        }
+        return earliest
+    }
+
+    /// The portion of partially generated text that is safe to show while
+    /// streaming: completed thought channels are removed (Gemma only), text
+    /// from a tool-call start onward is withheld when tools are active, and a
+    /// trailing partial match of either marker is held back until the next
+    /// token confirms or breaks it.
+    func streamingVisibleText(in raw: String, withholdToolCalls: Bool) -> String {
+        var text = raw
+        if self == .gemma {
+            text = Self.stripGemmaThoughtChannels(from: text)
+        }
+        if withholdToolCalls, let range = text.range(of: callStartMarker) {
+            text = String(text[..<range.lowerBound])
+        }
+        var candidates: [String] = []
+        if withholdToolCalls {
+            candidates.append(callStartMarker)
+        }
+        if self == .gemma {
+            candidates.append(contentsOf: Self.gemmaChannelOpenMarkers)
+        }
+        var cut = 0
+        for marker in candidates {
+            let maxLength = min(marker.count - 1, text.count)
+            guard maxLength > 0 else { continue }
+            for length in stride(from: maxLength, through: 1, by: -1)
+            where text.hasSuffix(String(marker.prefix(length))) {
+                cut = max(cut, length)
+                break
+            }
+        }
+        if cut > 0 {
+            text.removeLast(cut)
+        }
+        return text
+    }
 }
 
 /// A tool definition rendered into the system prompt.
@@ -477,7 +565,8 @@ extension LlamaToolCallFormat {
             remainder = rest
         }
         visible += remainder
-        return (visible.trimmingCharacters(in: .whitespacesAndNewlines), calls)
+        let stripped = Self.stripGemmaThoughtChannels(from: visible)
+        return (stripped.trimmingCharacters(in: .whitespacesAndNewlines), calls)
     }
 
     /// Finds the closing brace of a Gemma call body, skipping braces inside

--- a/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
@@ -427,7 +427,7 @@ extension LlamaToolCallFormat {
 
 extension LlamaToolCallFormat {
     /// Splits generated text into the visible response and any tool calls,
-    /// removing the call markup from the visible portion.
+    /// removing the call markup while preserving whitespace between rounds.
     func parseToolCalls(in text: String) -> (visibleText: String, calls: [LlamaParsedToolCall]) {
         switch self {
         case .hermesJSON:
@@ -467,7 +467,7 @@ extension LlamaToolCallFormat {
             remainder = afterStart[endRange.upperBound...]
         }
         visible += remainder
-        return (visible.trimmingCharacters(in: .whitespacesAndNewlines), calls)
+        return (visible, calls)
     }
 
     private func parseHermesCall(_ body: String) -> LlamaParsedToolCall? {
@@ -494,25 +494,34 @@ extension LlamaToolCallFormat {
     }
 
     private func parseQwenXMLCall(_ body: String) -> LlamaParsedToolCall? {
-        guard let nameStart = body.range(of: "<function=") else { return nil }
-        let afterName = body[nameStart.upperBound...]
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("<function=") else { return nil }
+        let afterName = trimmed.dropFirst("<function=".count)
         guard let nameEnd = afterName.firstIndex(of: ">") else { return nil }
         let name = String(afterName[..<nameEnd])
-        guard !name.isEmpty else { return nil }
+        guard !name.isEmpty, !name.contains("<"),
+            let functionEnd = afterName.range(of: "</function>"),
+            functionEnd.upperBound == afterName.endIndex,
+            nameEnd < functionEnd.lowerBound
+        else { return nil }
 
         var arguments: [String: Any] = [:]
-        var remainder = afterName[afterName.index(after: nameEnd)...]
-        while let paramStart = remainder.range(of: "<parameter=") {
-            let afterParam = remainder[paramStart.upperBound...]
-            guard let keyEnd = afterParam.firstIndex(of: ">") else { break }
+        var remainder = afterName[afterName.index(after: nameEnd) ..< functionEnd.lowerBound]
+            .drop(while: \.isWhitespace)
+        while !remainder.isEmpty {
+            guard remainder.hasPrefix("<parameter=") else { return nil }
+            let afterParam = remainder.dropFirst("<parameter=".count)
+            guard let keyEnd = afterParam.firstIndex(of: ">") else { return nil }
             let key = String(afterParam[..<keyEnd])
+            guard !key.isEmpty, !key.contains("<") else { return nil }
             let valueStart = afterParam.index(after: keyEnd)
-            guard let paramEnd = afterParam[valueStart...].range(of: "</parameter>") else { break }
+            guard let paramEnd = afterParam[valueStart...].range(of: "</parameter>") else { return nil }
             var value = String(afterParam[valueStart ..< paramEnd.lowerBound])
+            guard !value.contains("<parameter="), !value.contains("<parameter>") else { return nil }
             if value.hasPrefix("\n") { value.removeFirst() }
             if value.hasSuffix("\n") { value.removeLast() }
             arguments[key] = qwenXMLDecodedValue(value)
-            remainder = afterParam[paramEnd.upperBound...]
+            remainder = afterParam[paramEnd.upperBound...].drop(while: \.isWhitespace)
         }
 
         guard
@@ -573,7 +582,7 @@ extension LlamaToolCallFormat {
         }
         visible += remainder
         let stripped = Self.stripGemmaThoughtChannels(from: visible)
-        return (stripped.trimmingCharacters(in: .whitespacesAndNewlines), calls)
+        return (stripped, calls)
     }
 
     /// Finds the closing brace of a Gemma call body, skipping braces inside

--- a/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
@@ -98,7 +98,11 @@ enum LlamaToolCallFormat: Sendable, Equatable {
     /// from a tool-call start onward is withheld when tools are active, and a
     /// trailing partial match of either marker is held back until the next
     /// token confirms or breaks it.
-    func streamingVisibleText(in raw: String, withholdToolCalls: Bool) -> String {
+    func streamingVisibleText(
+        in raw: String,
+        withholdToolCalls: Bool,
+        holdPartialMarkers: Bool = true
+    ) -> String {
         var text = raw
         if self == .gemma {
             text = Self.stripGemmaThoughtChannels(from: text)
@@ -106,6 +110,9 @@ enum LlamaToolCallFormat: Sendable, Equatable {
         if withholdToolCalls, let range = text.range(of: callStartMarker) {
             text = String(text[..<range.lowerBound])
         }
+        // Once a round has ended, a trailing marker prefix is real output,
+        // so release it rather than hold it back.
+        guard holdPartialMarkers else { return text }
         var candidates: [String] = []
         if withholdToolCalls {
             candidates.append(callStartMarker)

--- a/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
@@ -1,0 +1,337 @@
+import Foundation
+import Testing
+
+@testable import AnyLanguageModel
+
+#if Llama
+    @Suite("LlamaToolCallFormat")
+    struct LlamaToolCallFormatTests {
+        private let weatherTool = LlamaToolDefinition(
+            name: "get_weather",
+            description: "Get the current weather for a city",
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "city": [
+                        "type": "string",
+                        "description": "The city name",
+                    ]
+                ],
+                "required": ["city"],
+            ]
+        )
+
+        // MARK: - Detection
+
+        @Test func detectsGemmaFromTurnMarker() {
+            let template = "{{- '<|turn>' + role + '\\n' }}"
+            #expect(LlamaToolCallFormat.detect(template: template) == .gemma)
+        }
+
+        @Test func detectsQwenXMLFromFunctionMarker() {
+            let template = "{{- '<tool_call>\\n<function=' + tool_call.name + '>\\n' }}"
+            #expect(LlamaToolCallFormat.detect(template: template) == .qwenXML)
+        }
+
+        @Test func defaultsToHermesJSON() {
+            #expect(LlamaToolCallFormat.detect(template: "<|im_start|>{{ role }}") == .hermesJSON)
+            #expect(LlamaToolCallFormat.detect(template: nil) == .hermesJSON)
+        }
+
+        // MARK: - System prompt rendering
+
+        @Test func hermesSystemMessageWrapsToolSpecs() {
+            let message = LlamaToolCallFormat.hermesJSON.systemMessage(
+                existingText: "You are helpful.",
+                tools: [weatherTool]
+            )
+            #expect(message.hasPrefix("You are helpful.\n\n# Tools"))
+            #expect(message.contains("<tools>"))
+            #expect(message.contains("\"name\":\"get_weather\""))
+            #expect(message.contains("{\"name\": <function-name>, \"arguments\": <args-json-object>}"))
+        }
+
+        @Test func qwenXMLSystemMessagePutsToolsFirst() {
+            let message = LlamaToolCallFormat.qwenXML.systemMessage(
+                existingText: "You are helpful.",
+                tools: [weatherTool]
+            )
+            #expect(message.hasPrefix("# Tools"))
+            #expect(message.hasSuffix("You are helpful."))
+            #expect(message.contains("<function=example_function_name>"))
+        }
+
+        @Test func gemmaSystemMessageAppendsDeclarations() {
+            let message = LlamaToolCallFormat.gemma.systemMessage(
+                existingText: "You are helpful.",
+                tools: [weatherTool]
+            )
+            #expect(message.hasPrefix("You are helpful.<|tool>declaration:get_weather{"))
+            #expect(message.hasSuffix("<tool|>"))
+            #expect(message.contains("description:<|\"|>Get the current weather for a city<|\"|>"))
+            #expect(message.contains("city:{description:<|\"|>The city name<|\"|>,type:<|\"|>STRING<|\"|>}"))
+            #expect(message.contains("required:[<|\"|>city<|\"|>]"))
+            #expect(message.contains("type:<|\"|>OBJECT<|\"|>"))
+        }
+
+        @Test func emptyToolListLeavesSystemTextUntouched() {
+            let message = LlamaToolCallFormat.hermesJSON.systemMessage(existingText: "Hi.", tools: [])
+            #expect(message == "Hi.")
+        }
+
+        // MARK: - Hermes JSON parsing
+
+        @Test func parsesHermesCall() {
+            let text = """
+                Let me check that for you.
+                <tool_call>
+                {"name": "get_weather", "arguments": {"city": "Paris"}}
+                </tool_call>
+                """
+            let (visible, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
+            #expect(visible == "Let me check that for you.")
+            #expect(calls.count == 1)
+            #expect(calls.first?.name == "get_weather")
+            #expect(calls.first?.argumentsJSON == "{\"city\":\"Paris\"}")
+        }
+
+        @Test func parsesHermesCallWithStringEncodedArguments() {
+            let text = "<tool_call>{\"name\": \"f\", \"arguments\": \"{\\\"a\\\": 1}\"}</tool_call>"
+            let (_, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
+            #expect(calls.first?.argumentsJSON == "{\"a\": 1}")
+        }
+
+        @Test func parsesMultipleHermesCalls() {
+            let text = """
+                <tool_call>
+                {"name": "a", "arguments": {}}
+                </tool_call>
+                <tool_call>
+                {"name": "b", "arguments": {"x": 2}}
+                </tool_call>
+                """
+            let (visible, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
+            #expect(visible.isEmpty)
+            #expect(calls.map(\.name) == ["a", "b"])
+        }
+
+        @Test func plainTextHasNoHermesCalls() {
+            let (visible, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: "Just an answer.")
+            #expect(visible == "Just an answer.")
+            #expect(calls.isEmpty)
+        }
+
+        @Test func unterminatedHermesBlockStaysVisible() {
+            let text = "Answer <tool_call>{\"name\": \"a\""
+            let (visible, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
+            #expect(calls.isEmpty)
+            #expect(visible.contains("<tool_call>"))
+        }
+
+        // MARK: - Qwen XML parsing
+
+        @Test func parsesQwenXMLCall() {
+            let text = """
+                I will look that up.
+                <tool_call>
+                <function=get_weather>
+                <parameter=city>
+                Paris
+                </parameter>
+                </function>
+                </tool_call>
+                """
+            let (visible, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
+            #expect(visible == "I will look that up.")
+            #expect(calls.count == 1)
+            #expect(calls.first?.name == "get_weather")
+            #expect(calls.first?.argumentsJSON == "{\"city\":\"Paris\"}")
+        }
+
+        @Test func qwenXMLPreservesMultilineParameterValues() {
+            let text = """
+                <tool_call>
+                <function=save_note>
+                <parameter=body>
+                line one
+                line two
+                </parameter>
+                </function>
+                </tool_call>
+                """
+            let (_, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
+            #expect(calls.first?.argumentsJSON == "{\"body\":\"line one\\nline two\"}")
+        }
+
+        @Test func qwenXMLDecodesStructuredParameterValues() {
+            let text = """
+                <tool_call>
+                <function=f>
+                <parameter=items>
+                ["a", "b"]
+                </parameter>
+                </function>
+                </tool_call>
+                """
+            let (_, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
+            #expect(calls.first?.argumentsJSON == "{\"items\":[\"a\",\"b\"]}")
+        }
+
+        // MARK: - Gemma parsing
+
+        @Test func parsesGemmaCall() {
+            let text = "<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>"
+            let (visible, calls) = LlamaToolCallFormat.gemma.parseToolCalls(in: text)
+            #expect(visible.isEmpty)
+            #expect(calls.count == 1)
+            #expect(calls.first?.name == "get_weather")
+            #expect(calls.first?.argumentsJSON == "{\"city\":\"Paris\"}")
+        }
+
+        @Test func gemmaQuotedStringsMayContainStructuralCharacters() {
+            let text = "<|tool_call>call:f{note:<|\"|>a, {b}: [c]<|\"|>}<tool_call|>"
+            let (_, calls) = LlamaToolCallFormat.gemma.parseToolCalls(in: text)
+            #expect(calls.first?.argumentsJSON == "{\"note\":\"a, {b}: [c]\"}")
+        }
+
+        @Test func gemmaParsesScalarAndNestedArguments() {
+            let text =
+                "<|tool_call>call:f{count:3,enabled:true,tags:[<|\"|>a<|\"|>,<|\"|>b<|\"|>],meta:{k:<|\"|>v<|\"|>}}<tool_call|>"
+            let (_, calls) = LlamaToolCallFormat.gemma.parseToolCalls(in: text)
+            #expect(
+                calls.first?.argumentsJSON
+                    == "{\"count\":3,\"enabled\":true,\"meta\":{\"k\":\"v\"},\"tags\":[\"a\",\"b\"]}"
+            )
+        }
+
+        @Test func gemmaCallWithoutTerminatorStillParses() {
+            let text = "<|tool_call>call:f{city:<|\"|>Paris<|\"|>}"
+            let (_, calls) = LlamaToolCallFormat.gemma.parseToolCalls(in: text)
+            #expect(calls.first?.name == "f")
+        }
+
+        // MARK: - Transcript replay round trips
+
+        @Test func hermesAssistantTextRoundTrips() {
+            let call = LlamaParsedToolCall(name: "get_weather", argumentsJSON: "{\"city\":\"Paris\"}")
+            let text = LlamaToolCallFormat.hermesJSON.assistantText(for: [call], precededByContent: false)
+            let (_, parsed) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
+            #expect(parsed == [call])
+        }
+
+        @Test func qwenXMLAssistantTextRoundTrips() {
+            let call = LlamaParsedToolCall(name: "get_weather", argumentsJSON: "{\"city\":\"Paris\"}")
+            let text = LlamaToolCallFormat.qwenXML.assistantText(for: [call], precededByContent: false)
+            let (_, parsed) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
+            #expect(parsed == [call])
+        }
+
+        @Test func gemmaAssistantTextRoundTrips() {
+            let call = LlamaParsedToolCall(name: "get_weather", argumentsJSON: "{\"city\":\"Paris\"}")
+            let text = LlamaToolCallFormat.gemma.assistantText(for: [call], precededByContent: false)
+            #expect(text == "<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>")
+            let (_, parsed) = LlamaToolCallFormat.gemma.parseToolCalls(in: text)
+            #expect(parsed == [call])
+        }
+
+        // MARK: - Tool response messages
+
+        @Test func hermesToolResponseIsAUserTurn() {
+            let message = LlamaToolCallFormat.hermesJSON.toolResponseMessage(
+                toolName: "get_weather",
+                content: "{\"temperature\": 21}"
+            )
+            #expect(message.role == "user")
+            #expect(message.content == "<tool_response>\n{\"temperature\": 21}\n</tool_response>")
+        }
+
+        @Test func gemmaToolResponseContinuesTheModelTurn() {
+            let message = LlamaToolCallFormat.gemma.toolResponseMessage(
+                toolName: "get_weather",
+                content: "{\"temperature\": 21}"
+            )
+            #expect(message.role == "tool")
+            #expect(
+                message.content
+                    == "<|tool_response>response:get_weather{temperature:21}<tool_response|>"
+            )
+        }
+
+        @Test func gemmaScalarToolResponseWrapsInValue() {
+            let message = LlamaToolCallFormat.gemma.toolResponseMessage(toolName: "f", content: "done")
+            #expect(message.content == "<|tool_response>response:f{value:<|\"|>done<|\"|>}<tool_response|>")
+        }
+    }
+
+    @Suite(
+        "LlamaLanguageModel tools",
+        .serialized,
+        .enabled(if: ProcessInfo.processInfo.environment["LLAMA_TOOL_MODEL_PATH"] != nil)
+    )
+    struct LlamaLanguageModelToolTests {
+        let model = LlamaLanguageModel(
+            modelPath: ProcessInfo.processInfo.environment["LLAMA_TOOL_MODEL_PATH"]!
+        )
+
+        @Test func executesToolAndAnswersFromItsOutput() async throws {
+            let weatherTool = spy(on: WeatherTool())
+            let session = LanguageModelSession(model: model, tools: [weatherTool])
+
+            var options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1024)
+            options[custom: LlamaLanguageModel.self] = .init(contextSize: 4096)
+            let response = try await session.respond(
+                to: "How's the weather in Paris? Use the getWeather tool.",
+                options: options
+            )
+
+            var foundToolOutput = false
+            for case let .toolOutput(toolOutput) in response.transcriptEntries {
+                #expect(toolOutput.toolName == weatherTool.name)
+                foundToolOutput = true
+            }
+            #expect(foundToolOutput)
+
+            let calls = await weatherTool.calls
+            #expect(calls.count == 1)
+            #expect(calls.first?.arguments.city.contains("Paris") == true)
+            #expect(response.content.lowercased().contains("72") || response.content.lowercased().contains("sunny"))
+            #expect(!response.content.contains("<tool_call>"))
+        }
+
+        @Test func replaysToolExchangeInFollowUpTurns() async throws {
+            let weatherTool = spy(on: WeatherTool())
+            let session = LanguageModelSession(model: model, tools: [weatherTool])
+
+            var options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1024)
+            options[custom: LlamaLanguageModel.self] = .init(contextSize: 4096)
+            _ = try await session.respond(
+                to: "How's the weather in Paris? Use the getWeather tool.",
+                options: options
+            )
+            let followUp = try await session.respond(
+                to: "What temperature did you just report, in Fahrenheit? Answer with just the number.",
+                options: options
+            )
+
+            let calls = await weatherTool.calls
+            #expect(calls.count == 1)
+            #expect(followUp.content.contains("72"))
+        }
+
+        @Test func answersDirectlyWhenNoToolApplies() async throws {
+            let weatherTool = spy(on: WeatherTool())
+            let session = LanguageModelSession(model: model, tools: [weatherTool])
+
+            var options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1024)
+            options[custom: LlamaLanguageModel.self] = .init(contextSize: 4096)
+            let response = try await session.respond(
+                to: "What is 2 + 2? Answer with just the number.",
+                options: options
+            )
+
+            let calls = await weatherTool.calls
+            #expect(calls.isEmpty)
+            #expect(response.content.contains("4"))
+        }
+    }
+#endif

--- a/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
@@ -234,6 +234,92 @@ import Testing
             #expect(parsed == [call])
         }
 
+        // MARK: - Gemma thought channels
+
+        @Test func stripsCompletedThoughtChannels() {
+            let text = "<|channel>thought\nThe user said hi.\n<channel|>Hello there!"
+            #expect(LlamaToolCallFormat.stripGemmaThoughtChannels(from: text) == "Hello there!")
+        }
+
+        @Test func stripsAlternateChannelSpelling() {
+            let text = "<|channel|>thought\nReasoning.\n<channel|>Answer."
+            #expect(LlamaToolCallFormat.stripGemmaThoughtChannels(from: text) == "Answer.")
+        }
+
+        @Test func stripsUnclosedThoughtChannelToEnd() {
+            let text = "Partial<|channel>thought\nstill thinking"
+            #expect(LlamaToolCallFormat.stripGemmaThoughtChannels(from: text) == "Partial")
+        }
+
+        @Test func stripsMultipleThoughtChannels() {
+            let text = "<|channel>thought\na\n<channel|>X<|channel>thought\nb\n<channel|>Y"
+            #expect(LlamaToolCallFormat.stripGemmaThoughtChannels(from: text) == "XY")
+        }
+
+        @Test func gemmaParseStripsThoughtChannels() {
+            let text = "<|channel>thought\nplan\n<channel|>Done.<|tool_call>call:f{}<tool_call|>"
+            let (visible, calls) = LlamaToolCallFormat.gemma.parseToolCalls(in: text)
+            #expect(visible == "Done.")
+            #expect(calls.count == 1)
+        }
+
+        // MARK: - Streaming visibility
+
+        @Test func streamingWithholdsPartialToolCallMarker() {
+            let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(
+                in: "The answer is<tool_",
+                withholdToolCalls: true
+            )
+            #expect(visible == "The answer is")
+        }
+
+        @Test func streamingFlushesBrokenMarkerPrefix() {
+            let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(
+                in: "5 < 10 is true",
+                withholdToolCalls: true
+            )
+            #expect(visible == "5 < 10 is true")
+        }
+
+        @Test func streamingTruncatesAtCompleteToolCallStart() {
+            let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(
+                in: "Checking.<tool_call>\n{\"name\":",
+                withholdToolCalls: true
+            )
+            #expect(visible == "Checking.")
+        }
+
+        @Test func streamingIgnoresToolMarkersWhenToolsInactive() {
+            let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(
+                in: "text <tool_call> more",
+                withholdToolCalls: false
+            )
+            #expect(visible == "text <tool_call> more")
+        }
+
+        @Test func streamingWithholdsGemmaThoughtChannel() {
+            let format = LlamaToolCallFormat.gemma
+            #expect(format.streamingVisibleText(in: "<|chan", withholdToolCalls: false) == "")
+            #expect(
+                format.streamingVisibleText(
+                    in: "<|channel>thought\nhmm",
+                    withholdToolCalls: false
+                ) == ""
+            )
+            #expect(
+                format.streamingVisibleText(
+                    in: "<|channel>thought\nhmm\n<channel|>Hi",
+                    withholdToolCalls: false
+                ) == "Hi"
+            )
+        }
+
+        @Test func streamingWithholdsGemmaPartialToolMarkerAfterThought() {
+            let format = LlamaToolCallFormat.gemma
+            let raw = "<|channel>thought\nplan\n<channel|>Sure.<|tool_"
+            #expect(format.streamingVisibleText(in: raw, withholdToolCalls: true) == "Sure.")
+        }
+
         // MARK: - Tool response messages
 
         @Test func hermesToolResponseIsAUserTurn() {
@@ -316,6 +402,38 @@ import Testing
             let calls = await weatherTool.calls
             #expect(calls.count == 1)
             #expect(followUp.content.contains("72"))
+        }
+
+        @Test func streamsToolExchangeProgressively() async throws {
+            let weatherTool = spy(on: WeatherTool())
+            let session = LanguageModelSession(model: model, tools: [weatherTool])
+
+            var options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1024)
+            options[custom: LlamaLanguageModel.self] = .init(contextSize: 4096)
+            let stream = session.streamResponse(
+                to: "How's the weather in Paris? Use the getWeather tool.",
+                options: options
+            )
+            var snapshots: [String] = []
+            var sawToolOutputEntry = false
+            for try await snapshot in stream {
+                snapshots.append(snapshot.content)
+                for case .toolOutput(_) in snapshot.transcriptEntries {
+                    sawToolOutputEntry = true
+                }
+            }
+
+            let calls = await weatherTool.calls
+            #expect(calls.count == 1)
+            #expect(sawToolOutputEntry)
+            #expect(snapshots.count > 3)
+            let final = snapshots.last ?? ""
+            #expect(final.lowercased().contains("72") || final.lowercased().contains("sunny"))
+            for content in snapshots {
+                #expect(!content.contains("<tool_call>"))
+                #expect(!content.contains("<|tool_call>"))
+                #expect(!content.contains("<|channel"))
+            }
         }
 
         @Test func answersDirectlyWhenNoToolApplies() async throws {

--- a/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
@@ -4,6 +4,21 @@ import Testing
 @testable import AnyLanguageModel
 
 #if Llama
+    private struct LlamaSchemaOptOutTool: Tool {
+        let name = "innate_weather"
+        let description = "Weather lookup known to the model."
+        let includesSchemaInInstructions = false
+
+        var parameters: GenerationSchema {
+            Issue.record("An opted-out tool's schema should not be read for the prompt.")
+            return WeatherTool.Arguments.generationSchema
+        }
+
+        func call(arguments: WeatherTool.Arguments) async throws -> String {
+            arguments.city
+        }
+    }
+
     @Suite("LlamaToolCallFormat")
     struct LlamaToolCallFormatTests {
         private let weatherTool = LlamaToolDefinition(
@@ -79,6 +94,32 @@ import Testing
             #expect(message == "Hi.")
         }
 
+        @Test(
+            arguments: [LlamaToolCallFormat.hermesJSON, .qwenXML, .gemma],
+            [false, true]
+        )
+        func promptDefinitionsHonorSchemaOptOut(
+            format: LlamaToolCallFormat,
+            includeAdvertisedTool: Bool
+        ) throws {
+            let optedOutTool = LlamaSchemaOptOutTool()
+            var tools: [any Tool] = [optedOutTool]
+            if includeAdvertisedTool {
+                tools.append(WeatherTool())
+            }
+            let context = try LlamaLanguageModel.LlamaToolPromptContext(format: format, tools: tools)
+            #expect(context.definitions.map(\.name) == (includeAdvertisedTool ? ["getWeather"] : []))
+            let message = context.format.systemMessage(existingText: "Hi.", tools: context.definitions)
+            #expect(!message.contains(optedOutTool.name))
+            #expect(!message.contains(optedOutTool.description))
+            if includeAdvertisedTool {
+                #expect(message.contains("getWeather"))
+                #expect(message.contains("city"))
+            } else {
+                #expect(message == "Hi.")
+            }
+        }
+
         // MARK: - Hermes JSON parsing
 
         @Test func parsesHermesCall() {
@@ -89,7 +130,7 @@ import Testing
                 </tool_call>
                 """
             let (visible, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
-            #expect(visible == "Let me check that for you.")
+            #expect(visible == "Let me check that for you.\n")
             #expect(calls.count == 1)
             #expect(calls.first?.name == "get_weather")
             #expect(calls.first?.argumentsJSON == "{\"city\":\"Paris\"}")
@@ -111,7 +152,7 @@ import Testing
                 </tool_call>
                 """
             let (visible, calls) = LlamaToolCallFormat.hermesJSON.parseToolCalls(in: text)
-            #expect(visible.isEmpty)
+            #expect(visible == "\n")
             #expect(calls.map(\.name) == ["a", "b"])
         }
 
@@ -142,7 +183,7 @@ import Testing
                 </tool_call>
                 """
             let (visible, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
-            #expect(visible == "I will look that up.")
+            #expect(visible == "I will look that up.\n")
             #expect(calls.count == 1)
             #expect(calls.first?.name == "get_weather")
             #expect(calls.first?.argumentsJSON == "{\"city\":\"Paris\"}")
@@ -175,6 +216,44 @@ import Testing
                 """
             let (_, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
             #expect(calls.first?.argumentsJSON == "{\"items\":[\"a\",\"b\"]}")
+        }
+
+        @Test func qwenXMLAcceptsCompleteZeroArgumentCall() {
+            let text = "<tool_call><function=f></function></tool_call>"
+            let (_, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
+            #expect(calls == [LlamaParsedToolCall(name: "f", argumentsJSON: "{}")])
+        }
+
+        @Test func qwenXMLAcceptsMultipleCompleteParameters() {
+            let text = """
+                <tool_call>
+                <function=f>
+                <parameter=city>Paris</parameter>
+                <parameter=units>celsius</parameter>
+                </function>
+                </tool_call>
+                """
+            let (_, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: text)
+            #expect(calls.first?.argumentsJSON == "{\"city\":\"Paris\",\"units\":\"celsius\"}")
+        }
+
+        @Test(arguments: [
+            "<function=side_effect>",
+            "<function=f><parameter=city>Paris</parameter>",
+            "<function=f><parameter=city>Paris</function>",
+            "<function=f><parameter=city</function>",
+            "<function=f><parameter=city>Paris</parameter><parameter=units</function>",
+            "<function=f><parameter=city>Paris</parameter><parameter=units>celsius</function>",
+            "<function=f><parameter=city>Paris<parameter=units>celsius</parameter></function>",
+            "<function=f><parameter>Paris</parameter></function>",
+            "<function=f><parameter=>Paris</parameter></function>",
+            "<function=f><parameter=city</parameter></function>",
+            "<function=f><parameter=city>Paris</function></parameter>",
+            "<function=f></function><parameter=city>Paris</parameter>",
+        ])
+        func qwenXMLRejectsIncompleteOrMalformedCalls(body: String) {
+            let (_, calls) = LlamaToolCallFormat.qwenXML.parseToolCalls(in: "<tool_call>\(body)</tool_call>")
+            #expect(calls.isEmpty)
         }
 
         // MARK: - Gemma parsing
@@ -264,6 +343,32 @@ import Testing
         }
 
         // MARK: - Streaming visibility
+
+        @Test(
+            arguments: [LlamaToolCallFormat.hermesJSON, .qwenXML, .gemma],
+            [" ", "\n", "\n\n", "\t"]
+        )
+        func preservesWhitespaceBetweenToolRounds(format: LlamaToolCallFormat, separator: String) {
+            let markup = format.assistantText(
+                for: [LlamaParsedToolCall(name: "get_weather", argumentsJSON: "{\"city\":\"Paris\"}")],
+                precededByContent: false
+            )
+            let rounds = ["Checking." + separator + markup, markup, "It is 72."]
+            let response = rounds.map { format.parseToolCalls(in: $0).visibleText }.joined()
+            let streamed = rounds.map {
+                format.streamingVisibleText(in: $0, withholdToolCalls: true, holdPartialMarkers: false)
+            }.joined()
+            #expect(response == "Checking." + separator + "It is 72.")
+            #expect(response == streamed)
+        }
+
+        @Test(arguments: [LlamaToolCallFormat.hermesJSON, .qwenXML, .gemma])
+        func preservesWhitespaceInPlainText(format: LlamaToolCallFormat) {
+            let text = "\n  It is 72.\n"
+            let (visible, calls) = format.parseToolCalls(in: text)
+            #expect(visible == text)
+            #expect(calls.isEmpty)
+        }
 
         @Test func streamingWithholdsPartialToolCallMarker() {
             let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(

--- a/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
@@ -281,6 +281,15 @@ import Testing
             #expect(visible == "5 < 10 is true")
         }
 
+        @Test func streamingReleasesPartialMarkerAtEndOfRound() {
+            let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(
+                in: "The answer is <",
+                withholdToolCalls: true,
+                holdPartialMarkers: false
+            )
+            #expect(visible == "The answer is <")
+        }
+
         @Test func streamingTruncatesAtCompleteToolCallStart() {
             let visible = LlamaToolCallFormat.hermesJSON.streamingVisibleText(
                 in: "Checking.<tool_call>\n{\"name\":",


### PR DESCRIPTION
@james-333i's #216, cherry-picked onto `main` with his authorship intact: the two tool-calling commits, without the copies of #213, #214, #215, and #181 that #216 carried and that have since landed on their own.

Original description and review discussion: #216.