### PR TITLE
Preserve Gemma tool types and response whitespace

### DIFF
--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -846,21 +846,6 @@ import Foundation
             return try LlamaToolPromptContext(format: currentToolCallFormat(), tools: session.tools)
         }
 
-        private func toolOutputText(_ output: Transcript.ToolOutput) -> String {
-            var parts: [String] = []
-            for segment in output.segments {
-                switch segment {
-                case .text(let text):
-                    parts.append(text.content)
-                case .structure(let structure):
-                    parts.append(structure.content.jsonString)
-                case .image:
-                    break
-                }
-            }
-            return parts.joined(separator: "\n")
-        }
-
         private func makeTranscriptToolCalls(
             from parsedCalls: [LlamaParsedToolCall]
         ) throws -> [Transcript.ToolCall] {
@@ -1033,12 +1018,11 @@ import Foundation
                     }
 
                     guard let format = toolContext?.format else {
-                        if outputFormat == .gemma {
-                            text = LlamaToolCallFormat.stripGemmaThoughtChannels(from: accumulated)
-                                .trimmingCharacters(in: .whitespacesAndNewlines)
-                        } else {
-                            text = accumulated
-                        }
+                        text = outputFormat.streamingVisibleText(
+                            in: accumulated,
+                            withholdToolCalls: false,
+                            holdPartialMarkers: false
+                        )
                         break generationLoop
                     }
                     let (visibleText, parsedCalls) = format.parseToolCalls(in: accumulated)
@@ -2237,7 +2221,7 @@ import Foundation
                     guard let toolContext else { break }
                     let message = toolContext.format.toolResponseMessage(
                         toolName: output.toolName,
-                        content: toolOutputText(output)
+                        segments: output.segments
                     )
                     if let last = messages.last, last.role == message.role, last.role == "user",
                         last.content.hasSuffix("</tool_response>")
@@ -2260,12 +2244,12 @@ import Foundation
 
             if let toolContext, !toolContext.definitions.isEmpty {
                 if let systemIndex = messages.firstIndex(where: { $0.role == "system" }) {
-                    messages[systemIndex].content = toolContext.format.systemMessage(
+                    messages[systemIndex].content = try toolContext.format.systemMessage(
                         existingText: messages[systemIndex].content,
                         tools: toolContext.definitions
                     )
                 } else {
-                    let systemText = toolContext.format.systemMessage(
+                    let systemText = try toolContext.format.systemMessage(
                         existingText: "",
                         tools: toolContext.definitions
                     )

--- a/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
@@ -155,7 +155,7 @@ struct LlamaParsedToolCall: Equatable {
 extension LlamaToolCallFormat {
     /// Renders the tool section of the system prompt and merges it with any
     /// existing system text, following each template's own ordering.
-    func systemMessage(existingText: String, tools: [LlamaToolDefinition]) -> String {
+    func systemMessage(existingText: String, tools: [LlamaToolDefinition]) throws -> String {
         guard !tools.isEmpty else { return existingText }
         switch self {
         case .hermesJSON:
@@ -165,7 +165,7 @@ extension LlamaToolCallFormat {
             let block = qwenXMLToolsBlock(tools: tools)
             return existingText.isEmpty ? block : block + "\n\n" + existingText
         case .gemma:
-            let declarations = tools.map { "<|tool>" + gemmaDeclaration(for: $0) + "<tool|>" }.joined()
+            let declarations = try tools.map { "<|tool>" + (try gemmaDeclaration(for: $0)) + "<tool|>" }.joined()
             return existingText + declarations
         }
     }
@@ -234,13 +234,69 @@ extension LlamaToolCallFormat {
 // MARK: - Gemma declaration and argument notation
 
 extension LlamaToolCallFormat {
+    enum SchemaReferenceError: Error, Equatable {
+        case unresolvedReference(String)
+        case recursiveReference(String)
+    }
+
+    /// Gemma declarations cannot carry JSON Schema references. Inline them
+    /// before rendering, and reject cycles that cannot be expanded finitely.
+    private func gemmaResolvedSchema(
+        _ schema: [String: Any],
+        definitions: [String: [String: Any]],
+        resolving: Set<String> = []
+    ) throws -> [String: Any] {
+        if let reference = schema["$ref"] as? String {
+            guard !resolving.contains(reference) else {
+                throw SchemaReferenceError.recursiveReference(reference)
+            }
+            let prefix = "#/$defs/"
+            let name = String(reference.dropFirst(prefix.count))
+                .replacingOccurrences(of: "~1", with: "/")
+                .replacingOccurrences(of: "~0", with: "~")
+            guard reference.hasPrefix(prefix), let target = definitions[name] else {
+                throw SchemaReferenceError.unresolvedReference(reference)
+            }
+            var overrides = schema
+            overrides.removeValue(forKey: "$ref")
+            return try gemmaResolvedSchema(
+                target.merging(overrides, uniquingKeysWith: { _, override in override }),
+                definitions: definitions,
+                resolving: resolving.union([reference])
+            )
+        }
+
+        var resolved = schema
+        resolved.removeValue(forKey: "$defs")
+        if let properties = schema["properties"] as? [String: [String: Any]] {
+            resolved["properties"] = try properties.mapValues {
+                try gemmaResolvedSchema($0, definitions: definitions, resolving: resolving)
+            }
+        }
+        if let items = schema["items"] as? [String: Any] {
+            resolved["items"] = try gemmaResolvedSchema(items, definitions: definitions, resolving: resolving)
+        }
+        for keyword in ["anyOf", "allOf", "oneOf"] {
+            if let choices = schema[keyword] as? [[String: Any]] {
+                resolved[keyword] = try choices.map {
+                    try gemmaResolvedSchema($0, definitions: definitions, resolving: resolving)
+                }
+            }
+        }
+        return resolved
+    }
+
     /// Renders one Gemma 4 function declaration:
     /// `declaration:name{description:<|"|>...<|"|>,parameters:{...}}`.
     /// Types are uppercased and strings are quoted with the `<|"|>` token, per
     /// the canonical template's `format_function_declaration` macro.
-    fileprivate func gemmaDeclaration(for tool: LlamaToolDefinition) -> String {
+    fileprivate func gemmaDeclaration(for tool: LlamaToolDefinition) throws -> String {
         var rendered = "declaration:\(tool.name){description:\(gemmaQuote(tool.description))"
         if let parameters = tool.parameters {
+            let parameters = try gemmaResolvedSchema(
+                parameters,
+                definitions: parameters["$defs"] as? [String: [String: Any]] ?? [:]
+            )
             rendered += ",parameters:{"
             var parts: [String] = []
             if let properties = parameters["properties"] as? [String: Any], !properties.isEmpty {
@@ -273,21 +329,7 @@ extension LlamaToolCallFormat {
                 fields.append("enum:[\(items)]")
             }
             if type == "ARRAY", let items = value["items"] as? [String: Any], !items.isEmpty {
-                var itemFields: [String] = []
-                for itemKey in items.keys.sorted() {
-                    guard let itemValue = items[itemKey] else { continue }
-                    if itemKey == "type", let itemType = itemValue as? String {
-                        itemFields.append("type:\(gemmaQuote(itemType.uppercased()))")
-                    } else if itemKey == "properties", let nested = itemValue as? [String: Any] {
-                        itemFields.append("properties:{" + gemmaProperties(nested) + "}")
-                    } else if itemKey == "required", let required = itemValue as? [Any] {
-                        let names = required.map { gemmaQuote("\($0)") }.joined(separator: ",")
-                        itemFields.append("required:[\(names)]")
-                    } else {
-                        itemFields.append("\(itemKey):\(gemmaArgument(itemValue))")
-                    }
-                }
-                fields.append("items:{" + itemFields.joined(separator: ",") + "}")
+                fields.append("items:{" + gemmaArrayItems(items) + "}")
             }
             if type == "OBJECT", let nested = value["properties"] as? [String: Any] {
                 fields.append("properties:{" + gemmaProperties(nested) + "}")
@@ -300,6 +342,23 @@ extension LlamaToolCallFormat {
             parts.append("\(key):{" + fields.joined(separator: ",") + "}")
         }
         return parts.joined(separator: ",")
+    }
+
+    private func gemmaArrayItems(_ items: [String: Any]) -> String {
+        var fields: [String] = []
+        for key in items.keys.sorted() {
+            guard let value = items[key] else { continue }
+            if key == "type", let type = value as? String {
+                fields.append("type:\(gemmaQuote(type.uppercased()))")
+            } else if key == "properties", let nested = value as? [String: Any] {
+                fields.append("properties:{" + gemmaProperties(nested) + "}")
+            } else if key == "items", let nested = value as? [String: Any] {
+                fields.append("items:{" + gemmaArrayItems(nested) + "}")
+            } else {
+                fields.append("\(key):\(gemmaArgument(value))")
+            }
+        }
+        return fields.joined(separator: ",")
     }
 
     fileprivate func gemmaQuote(_ string: String) -> String {
@@ -332,6 +391,24 @@ extension LlamaToolCallFormat {
             return "[" + array.map { gemmaArgument($0) }.joined(separator: ",") + "]"
         default:
             return gemmaQuote("\(value)")
+        }
+    }
+
+    private func gemmaArgument(_ content: GeneratedContent) -> String {
+        switch content.kind {
+        case .null:
+            return "null"
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .number(let value):
+            return gemmaArgument(NSNumber(value: value))
+        case .string(let value):
+            return gemmaQuote(value)
+        case .array(let elements):
+            return "[" + elements.map { gemmaArgument($0) }.joined(separator: ",") + "]"
+        case .structure(let properties, _):
+            let fields = properties.keys.sorted().map { "\($0):\(gemmaArgument(properties[$0]!))" }
+            return "{" + fields.joined(separator: ",") + "}"
         }
     }
 
@@ -405,20 +482,43 @@ extension LlamaToolCallFormat {
     /// Renders one tool output as the message that carries it back to the model.
     /// Hermes and Qwen XML formats deliver results inside a user turn; Gemma 4
     /// continues the open model turn with a `<|tool_response>` block.
-    func toolResponseMessage(toolName: String, content: String) -> (role: String, content: String) {
+    /// Gemma preserves segment types, wrapping non-object values in `value`
+    /// and collecting multiple segments into an array in their original order.
+    func toolResponseMessage(
+        toolName: String,
+        segments: [Transcript.Segment]
+    ) -> (role: String, content: String) {
         switch self {
         case .hermesJSON, .qwenXML:
+            let content = segments.compactMap { segment -> String? in
+                switch segment {
+                case .text(let text): return text.content
+                case .structure(let structure): return structure.content.jsonString
+                case .image: return nil
+                }
+            }.joined(separator: "\n")
             return ("user", "<tool_response>\n\(content)\n</tool_response>")
         case .gemma:
-            let body: String
-            if let data = content.data(using: .utf8),
-                let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-            {
-                body = object.keys.sorted().map { "\($0):\(gemmaArgument(object[$0]!))" }.joined(separator: ",")
-            } else {
-                body = "value:\(gemmaArgument(content))"
+            let values = segments.compactMap { segment -> GeneratedContent? in
+                switch segment {
+                case .text(let text): return GeneratedContent(text.content)
+                case .structure(let structure): return structure.content
+                case .image: return nil
+                }
             }
-            return ("tool", "<|tool_response>response:\(toolName){\(body)}<tool_response|>")
+            let content: GeneratedContent
+            switch values.count {
+            case 0: content = GeneratedContent("")
+            case 1: content = values[0]
+            default: content = GeneratedContent(kind: .array(values))
+            }
+            let body: String
+            if case .structure = content.kind {
+                body = gemmaArgument(content)
+            } else {
+                body = "{value:\(gemmaArgument(content))}"
+            }
+            return ("tool", "<|tool_response>response:\(toolName)\(body)<tool_response|>")
         }
     }
 }

--- a/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaToolCallFormat.swift
@@ -234,13 +234,25 @@ extension LlamaToolCallFormat {
 // MARK: - Gemma declaration and argument notation
 
 extension LlamaToolCallFormat {
-    enum SchemaReferenceError: Error, Equatable {
+    enum SchemaRenderingError: Error, Equatable, LocalizedError {
         case unresolvedReference(String)
         case recursiveReference(String)
+        case unsupportedComposition(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unresolvedReference(let reference):
+                return "Gemma tool schema reference '\(reference)' could not be resolved."
+            case .recursiveReference(let reference):
+                return "Gemma tool schema reference '\(reference)' is recursive and cannot be expanded."
+            case .unsupportedComposition(let keyword):
+                return "Gemma tool declarations do not support JSON Schema '\(keyword)' compositions."
+            }
+        }
     }
 
     /// Gemma declarations cannot carry JSON Schema references. Inline them
-    /// before rendering, and reject cycles that cannot be expanded finitely.
+    /// before rendering, and reject cycles and unsupported schema compositions.
     private func gemmaResolvedSchema(
         _ schema: [String: Any],
         definitions: [String: [String: Any]],
@@ -248,14 +260,14 @@ extension LlamaToolCallFormat {
     ) throws -> [String: Any] {
         if let reference = schema["$ref"] as? String {
             guard !resolving.contains(reference) else {
-                throw SchemaReferenceError.recursiveReference(reference)
+                throw SchemaRenderingError.recursiveReference(reference)
             }
             let prefix = "#/$defs/"
             let name = String(reference.dropFirst(prefix.count))
                 .replacingOccurrences(of: "~1", with: "/")
                 .replacingOccurrences(of: "~0", with: "~")
             guard reference.hasPrefix(prefix), let target = definitions[name] else {
-                throw SchemaReferenceError.unresolvedReference(reference)
+                throw SchemaRenderingError.unresolvedReference(reference)
             }
             var overrides = schema
             overrides.removeValue(forKey: "$ref")
@@ -264,6 +276,10 @@ extension LlamaToolCallFormat {
                 definitions: definitions,
                 resolving: resolving.union([reference])
             )
+        }
+
+        for keyword in ["anyOf", "allOf", "oneOf"] where schema[keyword] != nil {
+            throw SchemaRenderingError.unsupportedComposition(keyword)
         }
 
         var resolved = schema
@@ -275,13 +291,6 @@ extension LlamaToolCallFormat {
         }
         if let items = schema["items"] as? [String: Any] {
             resolved["items"] = try gemmaResolvedSchema(items, definitions: definitions, resolving: resolving)
-        }
-        for keyword in ["anyOf", "allOf", "oneOf"] {
-            if let choices = schema[keyword] as? [[String: Any]] {
-                resolved[keyword] = try choices.map {
-                    try gemmaResolvedSchema($0, definitions: definitions, resolving: resolving)
-                }
-            }
         }
         return resolved
     }

--- a/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
@@ -4,6 +4,33 @@ import Testing
 @testable import AnyLanguageModel
 
 #if Llama
+    private struct LlamaNestedArgumentsTool: Tool {
+        let name = "find_weather"
+        let description = "Find weather for a location."
+
+        @Generable
+        enum Units {
+            case celsius
+            case fahrenheit
+        }
+
+        @Generable
+        struct Location {
+            var city: String
+            var units: Units
+        }
+
+        @Generable
+        struct Arguments {
+            var location: Location
+            var alternatives: [Location]
+        }
+
+        func call(arguments: Arguments) async throws -> String {
+            arguments.location.city
+        }
+    }
+
     private struct LlamaSchemaOptOutTool: Tool {
         let name = "innate_weather"
         let description = "Weather lookup known to the model."
@@ -55,8 +82,8 @@ import Testing
 
         // MARK: - System prompt rendering
 
-        @Test func hermesSystemMessageWrapsToolSpecs() {
-            let message = LlamaToolCallFormat.hermesJSON.systemMessage(
+        @Test func hermesSystemMessageWrapsToolSpecs() throws {
+            let message = try LlamaToolCallFormat.hermesJSON.systemMessage(
                 existingText: "You are helpful.",
                 tools: [weatherTool]
             )
@@ -66,8 +93,8 @@ import Testing
             #expect(message.contains("{\"name\": <function-name>, \"arguments\": <args-json-object>}"))
         }
 
-        @Test func qwenXMLSystemMessagePutsToolsFirst() {
-            let message = LlamaToolCallFormat.qwenXML.systemMessage(
+        @Test func qwenXMLSystemMessagePutsToolsFirst() throws {
+            let message = try LlamaToolCallFormat.qwenXML.systemMessage(
                 existingText: "You are helpful.",
                 tools: [weatherTool]
             )
@@ -76,8 +103,8 @@ import Testing
             #expect(message.contains("<function=example_function_name>"))
         }
 
-        @Test func gemmaSystemMessageAppendsDeclarations() {
-            let message = LlamaToolCallFormat.gemma.systemMessage(
+        @Test func gemmaSystemMessageAppendsDeclarations() throws {
+            let message = try LlamaToolCallFormat.gemma.systemMessage(
                 existingText: "You are helpful.",
                 tools: [weatherTool]
             )
@@ -89,8 +116,8 @@ import Testing
             #expect(message.contains("type:<|\"|>OBJECT<|\"|>"))
         }
 
-        @Test func emptyToolListLeavesSystemTextUntouched() {
-            let message = LlamaToolCallFormat.hermesJSON.systemMessage(existingText: "Hi.", tools: [])
+        @Test func emptyToolListLeavesSystemTextUntouched() throws {
+            let message = try LlamaToolCallFormat.hermesJSON.systemMessage(existingText: "Hi.", tools: [])
             #expect(message == "Hi.")
         }
 
@@ -109,7 +136,7 @@ import Testing
             }
             let context = try LlamaLanguageModel.LlamaToolPromptContext(format: format, tools: tools)
             #expect(context.definitions.map(\.name) == (includeAdvertisedTool ? ["getWeather"] : []))
-            let message = context.format.systemMessage(existingText: "Hi.", tools: context.definitions)
+            let message = try context.format.systemMessage(existingText: "Hi.", tools: context.definitions)
             #expect(!message.contains(optedOutTool.name))
             #expect(!message.contains(optedOutTool.description))
             if includeAdvertisedTool {
@@ -117,6 +144,91 @@ import Testing
                 #expect(message.contains("city"))
             } else {
                 #expect(message == "Hi.")
+            }
+        }
+
+        @Test func gemmaResolvesNestedGenerableToolArguments() throws {
+            let context = try LlamaLanguageModel.LlamaToolPromptContext(
+                format: .gemma,
+                tools: [LlamaNestedArgumentsTool()]
+            )
+            let message = try context.format.systemMessage(existingText: "", tools: context.definitions)
+            #expect(!message.contains("$ref"))
+            #expect(!message.contains("$defs"))
+            #expect(
+                message.contains(
+                    "location:{description:<|\"|>Generated Location<|\"|>,properties:{city:{type:<|\"|>STRING<|\"|>}"
+                )
+            )
+            #expect(
+                message.contains(
+                    "alternatives:{items:{additionalProperties:false,description:<|\"|>Generated Location<|\"|>,properties:{city:"
+                )
+            )
+            #expect(
+                message.contains(
+                    "units:{description:<|\"|>Generated Units<|\"|>,enum:[<|\"|>celsius<|\"|>,<|\"|>fahrenheit<|\"|>],type:<|\"|>STRING<|\"|>}"
+                )
+            )
+            #expect(message.components(separatedBy: "type:<|\"|>OBJECT<|\"|>").count == 4)
+        }
+
+        @Test func gemmaResolvesRootAndChainedEnumReferences() throws {
+            let tool = LlamaToolDefinition(
+                name: "f",
+                description: "",
+                parameters: [
+                    "$ref": "#/$defs/Arguments",
+                    "$defs": [
+                        "Arguments": [
+                            "type": "object",
+                            "properties": [
+                                "units": ["$ref": "#/$defs/Alias", "description": "Preferred units"],
+                                "choices": ["type": "array", "items": ["$ref": "#/$defs/Units~1~0"]],
+                                "groups": [
+                                    "type": "array",
+                                    "items": ["type": "array", "items": ["$ref": "#/$defs/Units~1~0"]],
+                                ],
+                            ],
+                        ],
+                        "Alias": ["$ref": "#/$defs/Units~1~0"],
+                        "Units/~": ["type": "string", "enum": ["celsius", "fahrenheit"]],
+                    ],
+                ]
+            )
+            let message = try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
+            let enumFields = "enum:[<|\"|>celsius<|\"|>,<|\"|>fahrenheit<|\"|>],type:<|\"|>STRING<|\"|>"
+            #expect(message.contains("units:{description:<|\"|>Preferred units<|\"|>,\(enumFields)}"))
+            #expect(message.contains("choices:{items:{\(enumFields)},type:<|\"|>ARRAY<|\"|>}"))
+            #expect(
+                message.contains("groups:{items:{items:{\(enumFields)},type:<|\"|>ARRAY<|\"|>},type:<|\"|>ARRAY<|\"|>}")
+            )
+            #expect(!message.contains("$ref"))
+        }
+
+        @Test func gemmaRejectsUnresolvedSchemaReferences() {
+            let tool = LlamaToolDefinition(name: "f", description: "", parameters: ["$ref": "#/$defs/Missing"])
+            #expect(throws: LlamaToolCallFormat.SchemaReferenceError.unresolvedReference("#/$defs/Missing")) {
+                try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
+            }
+        }
+
+        @Test func gemmaRejectsRecursiveSchemaReferences() {
+            let tool = LlamaToolDefinition(
+                name: "f",
+                description: "",
+                parameters: [
+                    "$ref": "#/$defs/Node",
+                    "$defs": [
+                        "Node": [
+                            "type": "object",
+                            "properties": ["children": ["type": "array", "items": ["$ref": "#/$defs/Node"]]],
+                        ]
+                    ],
+                ]
+            )
+            #expect(throws: LlamaToolCallFormat.SchemaReferenceError.recursiveReference("#/$defs/Node")) {
+                try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
             }
         }
 
@@ -345,6 +457,21 @@ import Testing
         // MARK: - Streaming visibility
 
         @Test(
+            arguments: LlamaToolCallFormat.gemmaChannelOpenMarkers,
+            ["\n  Hello.\n", "  \t\n", " Hi <"]
+        )
+        func gemmaCompletedResponsePreservesWhitespace(channelMarker: String, answer: String) {
+            let raw = " \n" + channelMarker + "thought\nplan\n<channel|>" + answer
+            let visible = LlamaToolCallFormat.gemma.streamingVisibleText(
+                in: raw,
+                withholdToolCalls: false,
+                holdPartialMarkers: false
+            )
+            #expect(visible == " \n" + answer)
+            #expect(visible == LlamaToolCallFormat.gemma.parseToolCalls(in: raw).visibleText)
+        }
+
+        @Test(
             arguments: [LlamaToolCallFormat.hermesJSON, .qwenXML, .gemma],
             [" ", "\n", "\n\n", "\t"]
         )
@@ -439,16 +566,20 @@ import Testing
         @Test func hermesToolResponseIsAUserTurn() {
             let message = LlamaToolCallFormat.hermesJSON.toolResponseMessage(
                 toolName: "get_weather",
-                content: "{\"temperature\": 21}"
+                segments: [.text(.init(content: "{\"temperature\": 21}"))]
             )
             #expect(message.role == "user")
             #expect(message.content == "<tool_response>\n{\"temperature\": 21}\n</tool_response>")
         }
 
-        @Test func gemmaToolResponseContinuesTheModelTurn() {
+        @Test func gemmaToolResponseContinuesTheModelTurn() throws {
             let message = LlamaToolCallFormat.gemma.toolResponseMessage(
                 toolName: "get_weather",
-                content: "{\"temperature\": 21}"
+                segments: [
+                    .structure(
+                        .init(source: "get_weather", content: try GeneratedContent(json: "{\"temperature\":21}"))
+                    )
+                ]
             )
             #expect(message.role == "tool")
             #expect(
@@ -458,8 +589,68 @@ import Testing
         }
 
         @Test func gemmaScalarToolResponseWrapsInValue() {
-            let message = LlamaToolCallFormat.gemma.toolResponseMessage(toolName: "f", content: "done")
+            let message = LlamaToolCallFormat.gemma.toolResponseMessage(
+                toolName: "f",
+                segments: [.text(.init(content: "done"))]
+            )
             #expect(message.content == "<|tool_response>response:f{value:<|\"|>done<|\"|>}<tool_response|>")
+        }
+
+        @Test(arguments: [
+            ("[\"a\"]", "{value:[<|\"|>a<|\"|>]}"),
+            ("3", "{value:3}"),
+            ("1.5", "{value:1.5}"),
+            ("true", "{value:true}"),
+            ("false", "{value:false}"),
+            ("null", "{value:null}"),
+            ("\"done\"", "{value:<|\"|>done<|\"|>}"),
+            ("[]", "{value:[]}"),
+            ("{}", "{}"),
+            ("{\"items\":[3,true,null]}", "{items:[3,true,null]}"),
+        ])
+        func gemmaStructuredToolResponsePreservesType(testCase: (String, String)) throws {
+            let (json, body) = testCase
+            let message = LlamaToolCallFormat.gemma.toolResponseMessage(
+                toolName: "f",
+                segments: [.structure(.init(source: "f", content: try GeneratedContent(json: json)))]
+            )
+            #expect(message.content == "<|tool_response>response:f\(body)<tool_response|>")
+        }
+
+        @Test(arguments: ["[\"a\"]", "3", "true", "null", "{\"items\":[3]}", "\"done\""])
+        func gemmaTextToolResponseStaysText(text: String) {
+            let message = LlamaToolCallFormat.gemma.toolResponseMessage(
+                toolName: "f",
+                segments: [.text(.init(content: text))]
+            )
+            #expect(message.content == "<|tool_response>response:f{value:<|\"|>\(text)<|\"|>}<tool_response|>")
+        }
+
+        @Test func gemmaMixedToolResponsePreservesSegmentTypesAndOrder() throws {
+            let message = LlamaToolCallFormat.gemma.toolResponseMessage(
+                toolName: "f",
+                segments: [
+                    .text(.init(content: "Count:")),
+                    .structure(.init(source: "f", content: GeneratedContent(3))),
+                    .structure(.init(source: "f", content: try GeneratedContent(json: "[true]"))),
+                ]
+            )
+            #expect(
+                message.content == "<|tool_response>response:f{value:[<|\"|>Count:<|\"|>,3,[true]]}<tool_response|>"
+            )
+        }
+
+        @Test(arguments: [LlamaToolCallFormat.hermesJSON, .qwenXML])
+        func textToolResponseFormatsStillJoinSegments(format: LlamaToolCallFormat) {
+            let message = format.toolResponseMessage(
+                toolName: "f",
+                segments: [
+                    .text(.init(content: "Count:")),
+                    .structure(.init(source: "f", content: GeneratedContent(3))),
+                ]
+            )
+            #expect(message.role == "user")
+            #expect(message.content == "<tool_response>\nCount:\n3\n</tool_response>")
         }
     }
 

--- a/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
+++ b/Tests/AnyLanguageModelTests/LlamaToolCallFormatTests.swift
@@ -208,7 +208,7 @@ import Testing
 
         @Test func gemmaRejectsUnresolvedSchemaReferences() {
             let tool = LlamaToolDefinition(name: "f", description: "", parameters: ["$ref": "#/$defs/Missing"])
-            #expect(throws: LlamaToolCallFormat.SchemaReferenceError.unresolvedReference("#/$defs/Missing")) {
+            #expect(throws: LlamaToolCallFormat.SchemaRenderingError.unresolvedReference("#/$defs/Missing")) {
                 try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
             }
         }
@@ -227,9 +227,74 @@ import Testing
                     ],
                 ]
             )
-            #expect(throws: LlamaToolCallFormat.SchemaReferenceError.recursiveReference("#/$defs/Node")) {
+            #expect(throws: LlamaToolCallFormat.SchemaRenderingError.recursiveReference("#/$defs/Node")) {
                 try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
             }
+        }
+
+        enum SchemaPosition: CaseIterable {
+            case root, property, arrayItem
+
+            func wrap(_ schema: DynamicGenerationSchema) -> DynamicGenerationSchema {
+                switch self {
+                case .root:
+                    return schema
+                case .property:
+                    return DynamicGenerationSchema(
+                        name: "Arguments",
+                        properties: [.init(name: "value", schema: schema)]
+                    )
+                case .arrayItem:
+                    return DynamicGenerationSchema(
+                        name: "Arguments",
+                        properties: [.init(name: "values", schema: .init(arrayOf: schema))]
+                    )
+                }
+            }
+
+            func wrap(_ schema: [String: Any]) -> [String: Any] {
+                switch self {
+                case .root: return schema
+                case .property: return ["type": "object", "properties": ["value": schema]]
+                case .arrayItem:
+                    return ["type": "object", "properties": ["values": ["type": "array", "items": schema]]]
+                }
+            }
+        }
+
+        @Test(arguments: SchemaPosition.allCases)
+        func gemmaRejectsReferencedDynamicUnions(position: SchemaPosition) throws {
+            let choice = DynamicGenerationSchema(
+                name: "Choice",
+                anyOf: [.init(type: String.self), .init(type: Int.self)]
+            )
+            let schema = try GenerationSchema(root: position.wrap(choice), dependencies: [])
+            let data = try JSONEncoder().encode(schema)
+            let parameters = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let tool = LlamaToolDefinition(name: "f", description: "", parameters: parameters)
+            #expect(throws: LlamaToolCallFormat.SchemaRenderingError.unsupportedComposition("anyOf")) {
+                try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
+            }
+        }
+
+        @Test(arguments: SchemaPosition.allCases, ["anyOf", "oneOf", "allOf"])
+        func gemmaRejectsInlineSchemaCompositions(position: SchemaPosition, keyword: String) {
+            let parameters = position.wrap([keyword: [["type": "string"], ["type": "integer"]]])
+            let tool = LlamaToolDefinition(name: "f", description: "", parameters: parameters)
+            #expect(throws: LlamaToolCallFormat.SchemaRenderingError.unsupportedComposition(keyword)) {
+                try LlamaToolCallFormat.gemma.systemMessage(existingText: "", tools: [tool])
+            }
+        }
+
+        @Test(arguments: [LlamaToolCallFormat.hermesJSON, .qwenXML])
+        func otherFormatsPreserveUnionSchemas(format: LlamaToolCallFormat) throws {
+            let tool = LlamaToolDefinition(
+                name: "f",
+                description: "",
+                parameters: ["anyOf": [["type": "string"], ["type": "integer"]]]
+            )
+            let message = try format.systemMessage(existingText: "", tools: [tool])
+            #expect(message.contains("\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]"))
         }
 
         // MARK: - Hermes JSON parsing


### PR DESCRIPTION
Gemma tool declarations could describe nested argument types as strings, and transcript replay converted structured arrays and scalar tool results into quoted strings. This follow-up to #227 addresses all three comments from [Copilot's re-review](https://github.com/huggingface/AnyLanguageModel/pull/227#pullrequestreview-5170916135).

Gemma now explicitly rejects unsupported `anyOf`, `oneOf`, and `allOf` schemas at the root, in properties, and in array items, addressing the [latest review](https://github.com/huggingface/AnyLanguageModel/pull/228#pullrequestreview-5171213125).
