### PR TITLE
Forward all generation options to FoundationModels

### DIFF
--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -398,17 +398,24 @@
 
     @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
     extension GenerationOptions {
-        fileprivate func toFoundationModels() -> FoundationModels.GenerationOptions {
-            var options = FoundationModels.GenerationOptions()
-
-            if let temperature = self.temperature {
-                options.temperature = temperature
+        func toFoundationModels() -> FoundationModels.GenerationOptions {
+            let sampling: FoundationModels.GenerationOptions.SamplingMode?
+            switch self.sampling?.mode {
+            case .greedy:
+                sampling = .greedy
+            case .topK(let k, let seed):
+                sampling = .random(top: k, seed: seed)
+            case .nucleus(let probabilityThreshold, let seed):
+                sampling = .random(probabilityThreshold: probabilityThreshold, seed: seed)
+            case nil:
+                sampling = nil
             }
 
-            // Note: FoundationModels.GenerationOptions may not have all properties
-            // Only set those that are available
-
-            return options
+            return FoundationModels.GenerationOptions(
+                sampling: sampling,
+                temperature: temperature,
+                maximumResponseTokens: maximumResponseTokens
+            )
         }
     }
 

--- a/Tests/AnyLanguageModelTests/SystemLanguageModelTests.swift
+++ b/Tests/AnyLanguageModelTests/SystemLanguageModelTests.swift
@@ -2,6 +2,8 @@ import Testing
 @testable import AnyLanguageModel
 
 #if canImport(FoundationModels)
+    import struct FoundationModels.GenerationOptions
+
     private let isSystemLanguageModelAvailable = {
         if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
             return SystemLanguageModel.default.isAvailable
@@ -83,6 +85,64 @@ import Testing
 
     // MARK: - Test Suite
 
+    @Suite("SystemLanguageModel GenerationOptions")
+    struct SystemLanguageModelGenerationOptionsTests {
+        @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+        @Test(
+            "Forwards sampling modes",
+            arguments: [
+                (
+                    AnyLanguageModel.GenerationOptions.SamplingMode.greedy,
+                    FoundationModels.GenerationOptions.SamplingMode.greedy
+                ),
+                (
+                    AnyLanguageModel.GenerationOptions.SamplingMode.random(top: 40, seed: 123),
+                    FoundationModels.GenerationOptions.SamplingMode.random(top: 40, seed: 123)
+                ),
+                (
+                    AnyLanguageModel.GenerationOptions.SamplingMode.random(
+                        probabilityThreshold: 0.9,
+                        seed: 456
+                    ),
+                    FoundationModels.GenerationOptions.SamplingMode.random(
+                        probabilityThreshold: 0.9,
+                        seed: 456
+                    )
+                ),
+            ]
+        )
+        func forwardsSamplingMode(
+            sampling: AnyLanguageModel.GenerationOptions.SamplingMode,
+            expected: FoundationModels.GenerationOptions.SamplingMode
+        ) {
+            let converted = AnyLanguageModel.GenerationOptions(sampling: sampling).toFoundationModels()
+
+            #expect(converted.sampling == expected)
+        }
+
+        @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+        @Test("Forwards temperature and maximum response tokens")
+        func forwardsTemperatureAndMaximumResponseTokens() {
+            let converted = AnyLanguageModel.GenerationOptions(
+                temperature: 0.5,
+                maximumResponseTokens: 42
+            ).toFoundationModels()
+
+            #expect(converted.temperature == 0.5)
+            #expect(converted.maximumResponseTokens == 42)
+        }
+
+        @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+        @Test("Preserves unspecified options")
+        func preservesUnspecifiedOptions() {
+            let converted = AnyLanguageModel.GenerationOptions().toFoundationModels()
+
+            #expect(converted.sampling == nil)
+            #expect(converted.temperature == nil)
+            #expect(converted.maximumResponseTokens == nil)
+        }
+    }
+
     @Test("GenerationSchema merges duplicate defs for the same type")
     func generationSchemaMergesDuplicateDefsForSameType() {
         let schema = ContainerWithDuplicateNestedType.generationSchema
@@ -122,7 +182,7 @@ import Testing
             let model: SystemLanguageModel = SystemLanguageModel()
             let session = LanguageModelSession(model: model)
 
-            let options = GenerationOptions(temperature: 0.5)
+            let options = AnyLanguageModel.GenerationOptions(temperature: 0.5)
             let response = try await session.respond(
                 to: "Generate a number",
                 options: options


### PR DESCRIPTION
`GenerationOptions.toFoundationModels()` only forwarded temperature, causing `SystemLanguageModel` to ignore sampling modes and `maximumResponseTokens`. This forwards greedy, top-k, and nucleus sampling (including seeds), forwards the maximum token limit, and preserves nil defaults.