### PR TITLE
Expose MLX sampler parameters and honor GenerationOptions.sampling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         .package(url: "https://github.com/mattt/JSONSchema", from: "1.3.0"),
         .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "2.10549.0")),
         .package(url: "https://github.com/mattt/PartialJSONDecoder", from: "1.0.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.0.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.31.4"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "602.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
     ],

--- a/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
@@ -1342,17 +1342,41 @@ import Foundation
 
     // MARK: - Options Mapping
 
-    private func toGenerateParameters(_ options: GenerationOptions) -> MLXLMCommon.GenerateParameters {
+    /// Derives MLX sampler parameters from the core ``GenerationOptions/sampling`` (`SamplingMode`),
+    /// so `.sampling` acts as a unified sampling surface across backends (the same one Apple
+    /// FoundationModels consumes). Returns `nil` for any field the sampling mode doesn't express.
+    ///
+    /// Precedence at the call sites is custom-block → this (sampling) → existing default, so an
+    /// explicit `CustomGenerationOptions` value always wins. The `SamplingMode` seed is not
+    /// forwarded: `MLXLMCommon.GenerateParameters` has no per-call seed field.
+    func samplingDerivedParameters(
+        from options: GenerationOptions
+    ) -> (topP: Float?, topK: Int?, greedyTemperature: Float?) {
+        switch options.sampling?.mode {
+        case .greedy:
+            // Greedy = argmax; MLX realizes this with temperature 0.
+            return (topP: nil, topK: nil, greedyTemperature: 0)
+        case .topK(let k, _):
+            return (topP: nil, topK: k, greedyTemperature: nil)
+        case .nucleus(let threshold, _):
+            return (topP: Float(threshold), topK: nil, greedyTemperature: nil)
+        case nil:
+            return (topP: nil, topK: nil, greedyTemperature: nil)
+        }
+    }
+
+    func toGenerateParameters(_ options: GenerationOptions) -> MLXLMCommon.GenerateParameters {
         let custom = options[custom: MLXLanguageModel.self]
+        let derived = samplingDerivedParameters(from: options)
         return MLXLMCommon.GenerateParameters(
             maxTokens: options.maximumResponseTokens,
             maxKVSize: custom?.kvCache.maxSize,
             kvBits: custom?.kvCache.bits,
             kvGroupSize: custom?.kvCache.groupSize ?? 64,
             quantizedKVStart: custom?.kvCache.quantizedStart ?? 0,
-            temperature: Float(options.temperature ?? 0.6),
-            topP: custom?.topP ?? 1.0,
-            topK: custom?.topK ?? 0,
+            temperature: Float(options.temperature ?? derived.greedyTemperature.map(Double.init) ?? 0.6),
+            topP: custom?.topP ?? derived.topP ?? 1.0,
+            topK: custom?.topK ?? derived.topK ?? 0,
             minP: custom?.minP ?? 0.0,
             repetitionPenalty: custom?.repetitionPenalty,
             repetitionContextSize: custom?.repetitionContextSize ?? 20
@@ -1360,17 +1384,18 @@ import Foundation
     }
 
     /// Builds MLX parameters tuned for structured generation.
-    private func toStructuredGenerateParameters(_ options: GenerationOptions) -> MLXLMCommon.GenerateParameters {
+    func toStructuredGenerateParameters(_ options: GenerationOptions) -> MLXLMCommon.GenerateParameters {
         let custom = options[custom: MLXLanguageModel.self]
+        let derived = samplingDerivedParameters(from: options)
         return MLXLMCommon.GenerateParameters(
             maxTokens: options.maximumResponseTokens,
             maxKVSize: custom?.kvCache.maxSize,
             kvBits: custom?.kvCache.bits,
             kvGroupSize: custom?.kvCache.groupSize ?? 64,
             quantizedKVStart: custom?.kvCache.quantizedStart ?? 0,
-            temperature: Float(options.temperature ?? 0.2),
-            topP: custom?.topP ?? 0.95,
-            topK: custom?.topK ?? 0,
+            temperature: Float(options.temperature ?? derived.greedyTemperature.map(Double.init) ?? 0.2),
+            topP: custom?.topP ?? derived.topP ?? 0.95,
+            topK: custom?.topK ?? derived.topK ?? 0,
             minP: custom?.minP ?? 0.0,
             repetitionPenalty: custom?.repetitionPenalty ?? 1.1,
             repetitionContextSize: custom?.repetitionContextSize ?? 64

--- a/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
@@ -291,12 +291,15 @@ import Foundation
 
             /// Top-p (nucleus) sampling threshold.
             ///
-            /// Set this to `nil` to use the backend default (`1.0`, i.e. disabled).
+            /// Set this to `nil` to inherit nucleus sampling from `GenerationOptions.sampling`,
+            /// otherwise use `1.0` for regular generation or `0.95` for structured generation.
+            /// Set this to `1.0` to disable top-p sampling explicitly.
             public var topP: Float?
 
             /// Top-k sampling: restricts sampling to the `k` most likely tokens.
             ///
-            /// Set this to `nil` or `0` to disable top-k sampling.
+            /// Set this to `nil` to inherit top-k sampling from `GenerationOptions.sampling`,
+            /// otherwise disable top-k sampling. Set this to `0` to disable it explicitly.
             public var topK: Int?
 
             /// Min-p sampling threshold, relative to the most likely token's probability.
@@ -306,12 +309,13 @@ import Foundation
 
             /// Penalty factor applied to recently generated tokens to reduce repetition.
             ///
-            /// Set this to `nil` to disable the repetition penalty.
+            /// Set this to `nil` to use no penalty for regular generation or `1.1` for
+            /// structured generation. Set this to `1.0` to neutralize the penalty explicitly.
             public var repetitionPenalty: Float?
 
             /// Number of recent tokens considered by the repetition penalty.
             ///
-            /// Set this to `nil` to use the backend default.
+            /// Set this to `nil` to use `20` for regular generation or `64` for structured generation.
             public var repetitionContextSize: Int?
 
             /// Creates MLX-specific generation options.
@@ -322,12 +326,17 @@ import Foundation
             ///     template rendering context.
             ///   - userInputProcessing: Processing to apply to user media before input preparation.
             ///     Defaults to `nil`, which lets MLX use its default media handling.
-            ///   - topP: Top-p (nucleus) sampling threshold. Defaults to `nil` (backend default).
-            ///   - topK: Top-k sampling count. Defaults to `nil` (disabled).
+            ///   - topP: Top-p (nucleus) sampling threshold. Defaults to `nil`, which inherits
+            ///     nucleus sampling or uses `1.0` for regular generation and `0.95` for structured
+            ///     generation. Set to `1.0` to disable explicitly.
+            ///   - topK: Top-k sampling count. Defaults to `nil`, which inherits top-k sampling
+            ///     or disables it. Set to `0` to disable explicitly.
             ///   - minP: Min-p sampling threshold. Defaults to `nil` (disabled).
-            ///   - repetitionPenalty: Repetition penalty factor. Defaults to `nil` (disabled).
+            ///   - repetitionPenalty: Repetition penalty factor. Defaults to `nil`, which uses no
+            ///     penalty for regular generation or `1.1` for structured generation. Set to `1.0`
+            ///     to neutralize the penalty explicitly.
             ///   - repetitionContextSize: Repetition-penalty token window. Defaults to `nil`
-            ///     (backend default).
+            ///     (`20` for regular generation or `64` for structured generation).
             public init(
                 kvCache: KVCache,
                 userInputProcessing: UserInputProcessing?,
@@ -1374,7 +1383,7 @@ import Foundation
             kvBits: custom?.kvCache.bits,
             kvGroupSize: custom?.kvCache.groupSize ?? 64,
             quantizedKVStart: custom?.kvCache.quantizedStart ?? 0,
-            temperature: Float(options.temperature ?? derived.greedyTemperature.map(Double.init) ?? 0.6),
+            temperature: Float(derived.greedyTemperature.map(Double.init) ?? options.temperature ?? 0.6),
             topP: custom?.topP ?? derived.topP ?? 1.0,
             topK: custom?.topK ?? derived.topK ?? 0,
             minP: custom?.minP ?? 0.0,
@@ -1393,7 +1402,7 @@ import Foundation
             kvBits: custom?.kvCache.bits,
             kvGroupSize: custom?.kvCache.groupSize ?? 64,
             quantizedKVStart: custom?.kvCache.quantizedStart ?? 0,
-            temperature: Float(options.temperature ?? derived.greedyTemperature.map(Double.init) ?? 0.2),
+            temperature: Float(derived.greedyTemperature.map(Double.init) ?? options.temperature ?? 0.2),
             topP: custom?.topP ?? derived.topP ?? 0.95,
             topK: custom?.topK ?? derived.topK ?? 0,
             minP: custom?.minP ?? 0.0,

--- a/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
@@ -291,15 +291,18 @@ import Foundation
 
             /// Top-p (nucleus) sampling threshold.
             ///
-            /// Set this to `nil` to inherit nucleus sampling from `GenerationOptions.sampling`,
-            /// otherwise use `1.0` for regular generation or `0.95` for structured generation.
+            /// A non-`nil` value overrides nucleus sampling from `GenerationOptions.sampling`.
+            /// When this is `nil`, the nucleus sampling threshold is used if provided. If neither
+            /// supplies a threshold, regular generation uses `1.0` and structured generation uses `0.95`.
             /// Set this to `1.0` to disable top-p sampling explicitly.
             public var topP: Float?
 
             /// Top-k sampling: restricts sampling to the `k` most likely tokens.
             ///
-            /// Set this to `nil` to inherit top-k sampling from `GenerationOptions.sampling`,
-            /// otherwise disable top-k sampling. Set this to `0` to disable it explicitly.
+            /// A positive value restricts sampling to that many tokens. A non-`nil` value overrides
+            /// top-k sampling from `GenerationOptions.sampling`. When this is `nil`, the top-k count
+            /// is inherited if provided; if neither supplies a count, top-k sampling is disabled.
+            /// Set this to `0` to disable top-k sampling explicitly.
             public var topK: Int?
 
             /// Min-p sampling threshold, relative to the most likely token's probability.
@@ -326,11 +329,12 @@ import Foundation
             ///     template rendering context.
             ///   - userInputProcessing: Processing to apply to user media before input preparation.
             ///     Defaults to `nil`, which lets MLX use its default media handling.
-            ///   - topP: Top-p (nucleus) sampling threshold. Defaults to `nil`, which inherits
-            ///     nucleus sampling or uses `1.0` for regular generation and `0.95` for structured
-            ///     generation. Set to `1.0` to disable explicitly.
-            ///   - topK: Top-k sampling count. Defaults to `nil`, which inherits top-k sampling
-            ///     or disables it. Set to `0` to disable explicitly.
+            ///   - topP: Top-p (nucleus) sampling override. Defaults to `nil`, which inherits the
+            ///     core nucleus threshold if provided. When neither supplies a threshold, regular
+            ///     generation uses `1.0` and structured generation uses `0.95`. Set to `1.0` to disable.
+            ///   - topK: Top-k sampling override. Positive values restrict sampling to that many
+            ///     tokens; `0` disables it. Defaults to `nil`, which inherits the core top-k count
+            ///     if provided. When neither supplies a count, top-k sampling is disabled.
             ///   - minP: Min-p sampling threshold. Defaults to `nil` (disabled).
             ///   - repetitionPenalty: Repetition penalty factor. Defaults to `nil`, which uses no
             ///     penalty for regular generation or `1.1` for structured generation. Set to `1.0`
@@ -1356,21 +1360,21 @@ import Foundation
     /// FoundationModels consumes). Returns `nil` for any field the sampling mode doesn't express.
     ///
     /// Precedence at the call sites is custom-block → this (sampling) → existing default, so an
-    /// explicit `CustomGenerationOptions` value always wins. The `SamplingMode` seed is not
-    /// forwarded: `MLXLMCommon.GenerateParameters` has no per-call seed field.
+    /// explicit `CustomGenerationOptions` value always wins. The `SamplingMode` seed is forwarded
+    /// to `MLXLMCommon.GenerateParameters` for reproducible sampling.
     func samplingDerivedParameters(
         from options: GenerationOptions
-    ) -> (topP: Float?, topK: Int?, greedyTemperature: Float?) {
+    ) -> (topP: Float?, topK: Int?, greedyTemperature: Float?, seed: UInt64?) {
         switch options.sampling?.mode {
         case .greedy:
             // Greedy = argmax; MLX realizes this with temperature 0.
-            return (topP: nil, topK: nil, greedyTemperature: 0)
-        case .topK(let k, _):
-            return (topP: nil, topK: k, greedyTemperature: nil)
-        case .nucleus(let threshold, _):
-            return (topP: Float(threshold), topK: nil, greedyTemperature: nil)
+            return (topP: nil, topK: nil, greedyTemperature: 0, seed: nil)
+        case .topK(let k, let seed):
+            return (topP: nil, topK: k, greedyTemperature: nil, seed: seed)
+        case .nucleus(let threshold, let seed):
+            return (topP: Float(threshold), topK: nil, greedyTemperature: nil, seed: seed)
         case nil:
-            return (topP: nil, topK: nil, greedyTemperature: nil)
+            return (topP: nil, topK: nil, greedyTemperature: nil, seed: nil)
         }
     }
 
@@ -1388,7 +1392,8 @@ import Foundation
             topK: custom?.topK ?? derived.topK ?? 0,
             minP: custom?.minP ?? 0.0,
             repetitionPenalty: custom?.repetitionPenalty,
-            repetitionContextSize: custom?.repetitionContextSize ?? 20
+            repetitionContextSize: custom?.repetitionContextSize ?? 20,
+            seed: derived.seed
         )
     }
 
@@ -1407,7 +1412,8 @@ import Foundation
             topK: custom?.topK ?? derived.topK ?? 0,
             minP: custom?.minP ?? 0.0,
             repetitionPenalty: custom?.repetitionPenalty ?? 1.1,
-            repetitionContextSize: custom?.repetitionContextSize ?? 64
+            repetitionContextSize: custom?.repetitionContextSize ?? 64,
+            seed: derived.seed
         )
     }
 

--- a/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
@@ -289,6 +289,31 @@ import Foundation
                 additionalContext?.mapValues { $0.toSendable() }
             }
 
+            /// Top-p (nucleus) sampling threshold.
+            ///
+            /// Set this to `nil` to use the backend default (`1.0`, i.e. disabled).
+            public var topP: Float?
+
+            /// Top-k sampling: restricts sampling to the `k` most likely tokens.
+            ///
+            /// Set this to `nil` or `0` to disable top-k sampling.
+            public var topK: Int?
+
+            /// Min-p sampling threshold, relative to the most likely token's probability.
+            ///
+            /// Set this to `nil` or `0` to disable min-p sampling.
+            public var minP: Float?
+
+            /// Penalty factor applied to recently generated tokens to reduce repetition.
+            ///
+            /// Set this to `nil` to disable the repetition penalty.
+            public var repetitionPenalty: Float?
+
+            /// Number of recent tokens considered by the repetition penalty.
+            ///
+            /// Set this to `nil` to use the backend default.
+            public var repetitionContextSize: Int?
+
             /// Creates MLX-specific generation options.
             ///
             /// - Parameters:
@@ -297,14 +322,30 @@ import Foundation
             ///     template rendering context.
             ///   - userInputProcessing: Processing to apply to user media before input preparation.
             ///     Defaults to `nil`, which lets MLX use its default media handling.
+            ///   - topP: Top-p (nucleus) sampling threshold. Defaults to `nil` (backend default).
+            ///   - topK: Top-k sampling count. Defaults to `nil` (disabled).
+            ///   - minP: Min-p sampling threshold. Defaults to `nil` (disabled).
+            ///   - repetitionPenalty: Repetition penalty factor. Defaults to `nil` (disabled).
+            ///   - repetitionContextSize: Repetition-penalty token window. Defaults to `nil`
+            ///     (backend default).
             public init(
                 kvCache: KVCache,
                 userInputProcessing: UserInputProcessing?,
-                additionalContext: [String: AnyLanguageModel.JSONValue]?
+                additionalContext: [String: AnyLanguageModel.JSONValue]?,
+                topP: Float? = nil,
+                topK: Int? = nil,
+                minP: Float? = nil,
+                repetitionPenalty: Float? = nil,
+                repetitionContextSize: Int? = nil
             ) {
                 self.kvCache = kvCache
                 self.additionalContext = additionalContext
                 self.userInputProcessing = userInputProcessing
+                self.topP = topP
+                self.topK = topK
+                self.minP = minP
+                self.repetitionPenalty = repetitionPenalty
+                self.repetitionContextSize = repetitionContextSize
             }
 
             /// Default MLX generation options used when none are provided at runtime.
@@ -1310,9 +1351,11 @@ import Foundation
             kvGroupSize: custom?.kvCache.groupSize ?? 64,
             quantizedKVStart: custom?.kvCache.quantizedStart ?? 0,
             temperature: Float(options.temperature ?? 0.6),
-            topP: 1.0,
-            repetitionPenalty: nil,
-            repetitionContextSize: 20
+            topP: custom?.topP ?? 1.0,
+            topK: custom?.topK ?? 0,
+            minP: custom?.minP ?? 0.0,
+            repetitionPenalty: custom?.repetitionPenalty,
+            repetitionContextSize: custom?.repetitionContextSize ?? 20
         )
     }
 
@@ -1326,9 +1369,11 @@ import Foundation
             kvGroupSize: custom?.kvCache.groupSize ?? 64,
             quantizedKVStart: custom?.kvCache.quantizedStart ?? 0,
             temperature: Float(options.temperature ?? 0.2),
-            topP: 0.95,
-            repetitionPenalty: 1.1,
-            repetitionContextSize: 64
+            topP: custom?.topP ?? 0.95,
+            topK: custom?.topK ?? 0,
+            minP: custom?.minP ?? 0.0,
+            repetitionPenalty: custom?.repetitionPenalty ?? 1.1,
+            repetitionContextSize: custom?.repetitionContextSize ?? 64
         )
     }
 

--- a/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
+++ b/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
@@ -1017,7 +1017,9 @@ struct GeminiCustomOptionsTests {
         }
 
         @Test func samplingDerivationNucleus() {
-            let derived = samplingDerivedParameters(from: GenerationOptions(sampling: .random(probabilityThreshold: 0.9)))
+            let derived = samplingDerivedParameters(
+                from: GenerationOptions(sampling: .random(probabilityThreshold: 0.9))
+            )
             #expect(derived.topP == 0.9)
             #expect(derived.topK == nil)
             #expect(derived.greedyTemperature == nil)
@@ -1034,8 +1036,8 @@ struct GeminiCustomOptionsTests {
 
         @Test func samplingFillsWhenNoCustomBlock() {
             let params = toGenerateParameters(GenerationOptions(sampling: .random(top: 12)))
-            #expect(params.topK == 12)          // top-k now reaches MLX via sampling
-            #expect(params.topP == 1.0)         // untouched default
+            #expect(params.topK == 12)  // top-k now reaches MLX via sampling
+            #expect(params.topP == 1.0)  // untouched default
         }
 
         @Test func customBlockWinsOverSampling() {
@@ -1048,8 +1050,8 @@ struct GeminiCustomOptionsTests {
                 topK: 5
             )
             let params = toGenerateParameters(options)
-            #expect(params.topP == 0.3)         // custom wins over sampling's 0.9
-            #expect(params.topK == 5)           // custom wins (sampling expressed no top-k)
+            #expect(params.topP == 0.3)  // custom wins over sampling's 0.9
+            #expect(params.topK == 5)  // custom wins (sampling expressed no top-k)
         }
 
         @Test func greedyMapsToZeroTemperature() {

--- a/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
+++ b/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
@@ -1007,6 +1007,7 @@ struct GeminiCustomOptionsTests {
             #expect(derived.topP == nil)
             #expect(derived.topK == nil)
             #expect(derived.greedyTemperature == 0)
+            #expect(derived.seed == nil)
         }
 
         @Test func samplingDerivationTopK() {
@@ -1014,15 +1015,17 @@ struct GeminiCustomOptionsTests {
             #expect(derived.topK == 40)
             #expect(derived.topP == nil)
             #expect(derived.greedyTemperature == nil)
+            #expect(derived.seed == 7)
         }
 
         @Test func samplingDerivationNucleus() {
             let derived = samplingDerivedParameters(
-                from: GenerationOptions(sampling: .random(probabilityThreshold: 0.9))
+                from: GenerationOptions(sampling: .random(probabilityThreshold: 0.9, seed: 42))
             )
             #expect(derived.topP == 0.9)
             #expect(derived.topK == nil)
             #expect(derived.greedyTemperature == nil)
+            #expect(derived.seed == 42)
         }
 
         @Test func samplingDerivationNil() {
@@ -1030,9 +1033,31 @@ struct GeminiCustomOptionsTests {
             #expect(derived.topP == nil)
             #expect(derived.topK == nil)
             #expect(derived.greedyTemperature == nil)
+            #expect(derived.seed == nil)
         }
 
         // MARK: - Mapping precedence (custom-wins → sampling-fills → default)
+
+        @Test(arguments: [false, true], [nil, 0, 7, UInt64.max] as [UInt64?])
+        func samplingSeedIsPreserved(structured: Bool, seed: UInt64?) {
+            for sampling: GenerationOptions.SamplingMode in [
+                .random(top: 12, seed: seed), .random(probabilityThreshold: 0.9, seed: seed),
+            ] {
+                var options = GenerationOptions(sampling: sampling)
+                let params = structured ? toStructuredGenerateParameters(options) : toGenerateParameters(options)
+                #expect(params.seed == seed)
+
+                options[custom: MLXLanguageModel.self] = .init(
+                    kvCache: .default,
+                    userInputProcessing: nil,
+                    additionalContext: nil,
+                    topP: 0.8,
+                    topK: 5
+                )
+                let customParams = structured ? toStructuredGenerateParameters(options) : toGenerateParameters(options)
+                #expect(customParams.seed == seed)
+            }
+        }
 
         @Test func samplingFillsWhenNoCustomBlock() {
             let params = toGenerateParameters(GenerationOptions(sampling: .random(top: 12)))
@@ -1059,6 +1084,7 @@ struct GeminiCustomOptionsTests {
             let options = GenerationOptions(sampling: .greedy)
             let params = structured ? toStructuredGenerateParameters(options) : toGenerateParameters(options)
             #expect(params.temperature == 0)
+            #expect(params.seed == nil)
         }
 
         @Test(arguments: [false, true])

--- a/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
+++ b/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
@@ -1054,14 +1054,87 @@ struct GeminiCustomOptionsTests {
             #expect(params.topK == 5)  // custom wins (sampling expressed no top-k)
         }
 
-        @Test func greedyMapsToZeroTemperature() {
-            let params = toGenerateParameters(GenerationOptions(sampling: .greedy))
+        @Test(arguments: [false, true])
+        func greedyMapsToZeroTemperature(structured: Bool) {
+            let options = GenerationOptions(sampling: .greedy)
+            let params = structured ? toStructuredGenerateParameters(options) : toGenerateParameters(options)
             #expect(params.temperature == 0)
         }
 
-        @Test func explicitTemperatureWinsOverGreedy() {
-            let params = toGenerateParameters(GenerationOptions(sampling: .greedy, temperature: 0.7))
+        @Test(arguments: [false, true])
+        func greedyWinsOverExplicitTemperature(structured: Bool) {
+            let options = GenerationOptions(sampling: .greedy, temperature: 0.7)
+            let params = structured ? toStructuredGenerateParameters(options) : toGenerateParameters(options)
+            #expect(params.temperature == 0)
+        }
+
+        @Test(arguments: [false, true])
+        func explicitTemperatureIsPreservedWithoutGreedy(structured: Bool) {
+            for sampling: GenerationOptions.SamplingMode? in [
+                nil, .random(top: 12), .random(probabilityThreshold: 0.9),
+            ] {
+                let options = GenerationOptions(sampling: sampling, temperature: 0.7)
+                let params = structured ? toStructuredGenerateParameters(options) : toGenerateParameters(options)
+                #expect(params.temperature == Float(0.7))
+            }
+        }
+
+        // MARK: - Structured generation defaults and overrides
+
+        @Test(arguments: [false, true])
+        func structuredDefaultsArePreserved(withCustomBlock: Bool) {
+            var options = GenerationOptions()
+            if withCustomBlock {
+                options[custom: MLXLanguageModel.self] = .default
+            }
+            let params = toStructuredGenerateParameters(options)
+            #expect(params.temperature == Float(0.2))
+            #expect(params.topP == Float(0.95))
+            #expect(params.topK == 0)
+            #expect(params.minP == 0)
+            #expect(params.repetitionPenalty == Float(1.1))
+            #expect(params.repetitionContextSize == 64)
+        }
+
+        @Test(arguments: [false, true])
+        func structuredSamplingFillsUnsetCustomValues(withCustomBlock: Bool) {
+            var options = GenerationOptions(sampling: .random(probabilityThreshold: 0.8))
+            if withCustomBlock {
+                options[custom: MLXLanguageModel.self] = .default
+            }
+            let nucleusParams = toStructuredGenerateParameters(options)
+            #expect(nucleusParams.topP == Float(0.8))
+            #expect(nucleusParams.topK == 0)
+
+            options.sampling = .random(top: 12)
+            let topKParams = toStructuredGenerateParameters(options)
+            #expect(topKParams.topK == 12)
+            #expect(topKParams.topP == Float(0.95))
+        }
+
+        @Test(arguments: [
+            GenerationOptions.SamplingMode.random(top: 40),
+            GenerationOptions.SamplingMode.random(probabilityThreshold: 0.9),
+        ])
+        func structuredCustomValuesOverrideSamplingAndDefaults(sampling: GenerationOptions.SamplingMode) {
+            var options = GenerationOptions(sampling: sampling, temperature: 0.7)
+            options[custom: MLXLanguageModel.self] = .init(
+                kvCache: .default,
+                userInputProcessing: nil,
+                additionalContext: nil,
+                topP: 1.0,
+                topK: 0,
+                minP: 0.1,
+                repetitionPenalty: 1.0,
+                repetitionContextSize: 128
+            )
+            let params = toStructuredGenerateParameters(options)
             #expect(params.temperature == Float(0.7))
+            #expect(params.topP == 1.0)
+            #expect(params.topK == 0)
+            #expect(params.minP == Float(0.1))
+            #expect(params.repetitionPenalty == 1.0)
+            #expect(params.repetitionContextSize == 128)
         }
 
         @Test func codable() throws {

--- a/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
+++ b/Tests/AnyLanguageModelTests/CustomGenerationOptionsTests.swift
@@ -1000,6 +1000,68 @@ struct GeminiCustomOptionsTests {
             #expect(retrieved?.kvCache.quantizedStart == 256)
         }
 
+        // MARK: - SamplingMode → MLX derivation
+
+        @Test func samplingDerivationGreedy() {
+            let derived = samplingDerivedParameters(from: GenerationOptions(sampling: .greedy))
+            #expect(derived.topP == nil)
+            #expect(derived.topK == nil)
+            #expect(derived.greedyTemperature == 0)
+        }
+
+        @Test func samplingDerivationTopK() {
+            let derived = samplingDerivedParameters(from: GenerationOptions(sampling: .random(top: 40, seed: 7)))
+            #expect(derived.topK == 40)
+            #expect(derived.topP == nil)
+            #expect(derived.greedyTemperature == nil)
+        }
+
+        @Test func samplingDerivationNucleus() {
+            let derived = samplingDerivedParameters(from: GenerationOptions(sampling: .random(probabilityThreshold: 0.9)))
+            #expect(derived.topP == 0.9)
+            #expect(derived.topK == nil)
+            #expect(derived.greedyTemperature == nil)
+        }
+
+        @Test func samplingDerivationNil() {
+            let derived = samplingDerivedParameters(from: GenerationOptions())
+            #expect(derived.topP == nil)
+            #expect(derived.topK == nil)
+            #expect(derived.greedyTemperature == nil)
+        }
+
+        // MARK: - Mapping precedence (custom-wins → sampling-fills → default)
+
+        @Test func samplingFillsWhenNoCustomBlock() {
+            let params = toGenerateParameters(GenerationOptions(sampling: .random(top: 12)))
+            #expect(params.topK == 12)          // top-k now reaches MLX via sampling
+            #expect(params.topP == 1.0)         // untouched default
+        }
+
+        @Test func customBlockWinsOverSampling() {
+            var options = GenerationOptions(sampling: .random(probabilityThreshold: 0.9))
+            options[custom: MLXLanguageModel.self] = .init(
+                kvCache: .default,
+                userInputProcessing: nil,
+                additionalContext: nil,
+                topP: 0.3,
+                topK: 5
+            )
+            let params = toGenerateParameters(options)
+            #expect(params.topP == 0.3)         // custom wins over sampling's 0.9
+            #expect(params.topK == 5)           // custom wins (sampling expressed no top-k)
+        }
+
+        @Test func greedyMapsToZeroTemperature() {
+            let params = toGenerateParameters(GenerationOptions(sampling: .greedy))
+            #expect(params.temperature == 0)
+        }
+
+        @Test func explicitTemperatureWinsOverGreedy() {
+            let params = toGenerateParameters(GenerationOptions(sampling: .greedy, temperature: 0.7))
+            #expect(params.temperature == Float(0.7))
+        }
+
         @Test func codable() throws {
             let options = MLXLanguageModel.CustomGenerationOptions(
                 kvCache: .init(


### PR DESCRIPTION
@SpiraMira’s first two commits from #168, cherry-picked onto `main` with their authorship intact, plus test-formatting fixes and review follow-ups for greedy sampling, sampling seeds, structured-generation coverage, and option documentation.

MLX now reads `GenerationOptions.sampling` for top-k, top-p, and greedy sampling and exposes MLX-specific sampler controls through `CustomGenerationOptions`. Precedence is custom options, then sampling, then the existing defaults; structured generation retains its own defaults. Greedy sampling forces temperature zero in both paths, even when an explicit temperature is supplied. Top-k and nucleus seeds are forwarded in both paths; this requires `mlx-swift-lm` 3.31.4 or later, where per-generation seed support was added.

The speculative OS 27 `toolCallingMode` commit is excluded; #206 owns that SystemLanguageModel work. This replaces #168 because pushes to the contributor’s fork are blocked. Original description and review discussion: #168.