### PR TITLE
Preserve object and array shapes in union schemas

### DIFF
--- a/Sources/AnyLanguageModel/Shared/ToolSchemaNormalization.swift
+++ b/Sources/AnyLanguageModel/Shared/ToolSchemaNormalization.swift
@@ -184,13 +184,15 @@ private func strippingResidualRefs(_ value: Any, depth: Int) -> Any {
 
 /// Coerces `"type"` values so a chat template can render every property.
 ///
-/// A non-string `"type"` becomes a scalar string — an array-valued one becomes its
-/// first non-`"null"` element. A typeless `anyOf`/`oneOf` adopts the first non-null
-/// member's type and object/array shape, while other property or item schemas with no
-/// `"type"` get `"string"`. A `"properties"` or `"items"` value that is not a schema
-/// mapping is replaced with one, since templates hand those straight to filters that
-/// require a mapping. All of these are valid JSON Schema but throw in templates that
-/// inspect `"type"` directly. Well-formed schemas pass through unchanged.
+/// A non-string `"type"` becomes a scalar string;
+/// an array-valued one becomes its first non-`"null"` element.
+/// A typeless `anyOf`/`oneOf` adopts the first non-null member's type and object/array shape,
+/// while other property or item schemas with no `"type"` get `"string"`.
+/// A `"properties"` or `"items"` value that is not a schema mapping is replaced with one,
+/// since templates hand those straight to filters that require a mapping.
+/// All of these are valid JSON Schema,
+/// but throw in templates that inspect `"type"` directly.
+/// Well-formed schemas pass through unchanged.
 func normalizeToolSchemaTypes(_ schema: [String: Any]) -> [String: Any] {
     normalizeSchemaTypes(schema, depth: 0)
 }

--- a/Sources/AnyLanguageModel/Shared/ToolSchemaNormalization.swift
+++ b/Sources/AnyLanguageModel/Shared/ToolSchemaNormalization.swift
@@ -205,7 +205,10 @@ private func normalizeSchemaTypes(_ schema: [String: Any], depth: Int) -> [Strin
         let members = (["anyOf", "oneOf"].compactMap { normalized[$0] as? [Any] }).first
     {
         let member = members.compactMap { $0 as? [String: Any] }.first {
-            $0["type"] != nil && $0["type"] as? String != "null"
+            if let type = $0["type"] as? String { return type != "null" }
+            return ($0["type"] as? [Any])?.contains {
+                ($0 as? String).map { $0 != "null" } == true
+            } == true
         }
         normalized["type"] = member?["type"] ?? "string"
         for key in ["properties", "items"] where member?[key] != nil {

--- a/Sources/AnyLanguageModel/Shared/ToolSchemaNormalization.swift
+++ b/Sources/AnyLanguageModel/Shared/ToolSchemaNormalization.swift
@@ -185,11 +185,12 @@ private func strippingResidualRefs(_ value: Any, depth: Int) -> Any {
 /// Coerces `"type"` values so a chat template can render every property.
 ///
 /// A non-string `"type"` becomes a scalar string — an array-valued one becomes its
-/// first non-`"null"` element — and a property or item schema with no `"type"` gets
-/// `"string"`. A `"properties"` or `"items"` value that is not a schema mapping is
-/// replaced with one, since templates hand those straight to filters that require a
-/// mapping. All of these are valid JSON Schema but throw in templates that inspect
-/// `"type"` directly. Well-formed schemas pass through unchanged.
+/// first non-`"null"` element. A typeless `anyOf`/`oneOf` adopts the first non-null
+/// member's type and object/array shape, while other property or item schemas with no
+/// `"type"` get `"string"`. A `"properties"` or `"items"` value that is not a schema
+/// mapping is replaced with one, since templates hand those straight to filters that
+/// require a mapping. All of these are valid JSON Schema but throw in templates that
+/// inspect `"type"` directly. Well-formed schemas pass through unchanged.
 func normalizeToolSchemaTypes(_ schema: [String: Any]) -> [String: Any] {
     normalizeSchemaTypes(schema, depth: 0)
 }
@@ -197,6 +198,18 @@ func normalizeToolSchemaTypes(_ schema: [String: Any]) -> [String: Any] {
 private func normalizeSchemaTypes(_ schema: [String: Any], depth: Int) -> [String: Any] {
     guard depth < maxSchemaDepth else { return safeScalarSchema }
     var normalized = schema
+
+    if normalized["type"] == nil,
+        let members = (["anyOf", "oneOf"].compactMap { normalized[$0] as? [Any] }).first
+    {
+        let member = members.compactMap { $0 as? [String: Any] }.first {
+            $0["type"] != nil && $0["type"] as? String != "null"
+        }
+        normalized["type"] = member?["type"] ?? "string"
+        for key in ["properties", "items"] where member?[key] != nil {
+            normalized[key] = member?[key]
+        }
+    }
 
     if let type = normalized["type"], !(type is String) {
         let named = (type as? [Any])?.compactMap { $0 as? String }.filter { $0 != "null" }

--- a/Tests/AnyLanguageModelTests/ToolSchemaNormalizationTests.swift
+++ b/Tests/AnyLanguageModelTests/ToolSchemaNormalizationTests.swift
@@ -1528,8 +1528,8 @@ struct ToolSchemaNormalizationTests {
         let members = address?["anyOf"] as? [Any]
         #expect((members?.first as? [String: Any])?["type"] as? String == "object")
         #expect(((members?.first as? [String: Any])?["properties"] as? [String: Any])?["city"] != nil)
-        // The union leaf carries no scalar type of its own until normalization adds one.
-        #expect(address?["type"] as? String == "string")
+        // Normalization promotes the non-null union member's shape for the template.
+        #expect(address?["type"] as? String == "object")
         #expect(!containsRef(prepared))
     }
 

--- a/Tests/AnyLanguageModelTests/ToolSchemaNormalizationTests.swift
+++ b/Tests/AnyLanguageModelTests/ToolSchemaNormalizationTests.swift
@@ -121,6 +121,35 @@ struct ToolSchemaNormalizationTests {
         #expect(normalized["type"] == nil)
     }
 
+    @Test func promotesArrayShapeAfterArrayValuedNullMember() {
+        let schema: [String: Any] = [
+            "type": "object",
+            "properties": [
+                "addresses": [
+                    "anyOf": [
+                        ["type": ["null"]],
+                        [
+                            "type": "array",
+                            "items": [
+                                "type": "object",
+                                "properties": ["city": ["type": "string"]],
+                            ],
+                        ],
+                    ]
+                ]
+            ],
+        ]
+
+        let normalized = normalizeToolSchemaTypes(schema)
+
+        let properties = normalized["properties"] as? [String: Any]
+        let addresses = properties?["addresses"] as? [String: Any]
+        let items = addresses?["items"] as? [String: Any]
+        #expect(addresses?["type"] as? String == "array")
+        #expect(items?["type"] as? String == "object")
+        #expect((items?["properties"] as? [String: Any])?["city"] != nil)
+    }
+
     // MARK: - Nesting
 
     @Test func normalizesDeeplyNestedSchemas() {
@@ -1530,6 +1559,7 @@ struct ToolSchemaNormalizationTests {
         #expect(((members?.first as? [String: Any])?["properties"] as? [String: Any])?["city"] != nil)
         // Normalization promotes the non-null union member's shape for the template.
         #expect(address?["type"] as? String == "object")
+        #expect((address?["properties"] as? [String: Any])?["city"] != nil)
         #expect(!containsRef(prepared))
     }
 


### PR DESCRIPTION
Typeless anyOf and oneOf schemas were normalized to strings even when the first non-null member described an object or array. This promotes the member type and corresponding properties or items, preserving the nested contract while retaining the existing string fallback. Follow-up to https://github.com/huggingface/AnyLanguageModel/pull/177#pullrequestreview-5178101880.