### PR TITLE
Cache structured-generation token sets per loaded model

### DIFF
--- a/Sources/AnyLanguageModel/Models/CoreMLLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/CoreMLLanguageModel.swift
@@ -26,6 +26,7 @@
 
         private let model: Models.LanguageModel
         private let tokenizer: any Tokenizer
+        private let tokenCache: StructuredGenerationTokenCache
         private let chatTemplateHandler: (@Sendable (Instructions?, Prompt) -> [Message])?
         private let toolsHandler: (@Sendable ([any Tool]) -> [ToolSpec])?
 
@@ -64,6 +65,7 @@
 
             // Load the tokenizer
             self.tokenizer = try await model.tokenizer
+            self.tokenCache = StructuredGenerationTokenCache()
 
             self.chatTemplateHandler = chatTemplateHandler
             self.toolsHandler = toolsHandler
@@ -384,7 +386,7 @@
                 maximumTokens: maxTokens,
                 endTokens: endTokens
             )
-            var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+            var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: tokenCache)
             let json = try await generator.generate()
             return json
         }

--- a/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/LlamaLanguageModel.swift
@@ -458,6 +458,9 @@ import Foundation
         /// The model's vocabulary
         private var vocab: OpaquePointer?
 
+        /// Vocabulary-derived tokens shared across generations of this loaded model.
+        private var tokenCache: StructuredGenerationTokenCache?
+
         /// The multimodal projector context, when a projector file was provided
         private var mtmdContext: OpaquePointer?
         /// `mtmd_helper_eval_chunks` is not thread-safe and every multimodal generation
@@ -1334,6 +1337,9 @@ import Foundation
             // Initialize backend lazily - must be done before loading model
             llama_backend_init()
 
+            tokenCache = nil
+            vocab = nil
+
             // Free any existing model before loading a new one
             discardCachedSessionContext()
             if let existingContext = mtmdContext {
@@ -1368,6 +1374,7 @@ import Foundation
 
             self.model = loadedModel
             self.vocab = llama_model_get_vocab(loadedModel)
+            self.tokenCache = StructuredGenerationTokenCache()
             self.isModelLoaded = true
         }
 
@@ -1583,7 +1590,7 @@ import Foundation
                 endTokens: [],
                 tokenToTextFn: { [self] token in self.tokenToText(vocab: vocab, token: llama_token(token)) }
             )
-            var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+            var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: tokenCache)
             return try await generator.generate()
         }
 

--- a/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/MLXLanguageModel.swift
@@ -20,10 +20,16 @@ import Foundation
     import HuggingFace
     import Tokenizers
 
+    /// Keeps vocabulary-derived tokens alive with the loaded model and tokenizer.
+    private struct LoadedModelContext {
+        let context: ModelContext
+        let tokenCache = StructuredGenerationTokenCache()
+    }
+
     /// Wrapper to store model availability state in NSCache.
     private final class CachedModelState: NSObject, @unchecked Sendable {
         enum Value {
-            case loaded(ModelContext)
+            case loaded(LoadedModelContext)
             case failed(String)
         }
 
@@ -50,7 +56,7 @@ import Foundation
         func context(
             for key: String,
             loader: @escaping @Sendable () async throws -> ModelContext
-        ) async throws -> ModelContext {
+        ) async throws -> LoadedModelContext {
             let cacheKey = key as NSString
             if let cached = cache.object(forKey: cacheKey),
                 case .loaded(let context) = cached.value
@@ -68,7 +74,7 @@ import Foundation
 
             let task = Task {
                 let context = try await loader()
-                return CachedModelState(.loaded(context))
+                return CachedModelState(.loaded(LoadedModelContext(context: context)))
             }
             setInFlight(task, for: key)
 
@@ -731,7 +737,7 @@ import Foundation
         }
 
         /// Get or load model context with caching
-        private func loadContext(modelId: String, hub: HubClient?, directory: URL?) async throws -> ModelContext {
+        private func loadContext(modelId: String, hub: HubClient?, directory: URL?) async throws -> LoadedModelContext {
             let key = directory?.absoluteString ?? modelId
 
             return try await modelCache.context(for: key) {
@@ -941,13 +947,16 @@ import Foundation
             defer { Self.releaseGenerationSlot(for: session) }
 
             // Get cached or load fresh ModelContext
-            let context = try await loadContext(modelId: modelId, hub: hub, directory: directory)
+            let loaded = try await loadContext(modelId: modelId, hub: hub, directory: directory)
+            defer { withExtendedLifetime(loaded) {} }
+            let context = loaded.context
             let generationScope = beginGenerationScope()
             defer { endGenerationScope(generationScope) }
 
             if type != String.self {
                 let jsonString = try await generateStructuredJSON(
                     context: context,
+                    tokenCache: loaded.tokenCache,
                     session: session,
                     prompt: prompt,
                     schema: type.generationSchema,
@@ -1149,7 +1158,9 @@ import Foundation
 
                     do {
                         // Get cached or load fresh ModelContext
-                        let context = try await loadContext(modelId: modelId, hub: hub, directory: directory)
+                        let loaded = try await loadContext(modelId: modelId, hub: hub, directory: directory)
+                        defer { withExtendedLifetime(loaded) {} }
+                        let context = loaded.context
 
                         // Build chat inside task to avoid Sendable issues
                         let generateParameters = toGenerateParameters(options)
@@ -1324,7 +1335,9 @@ import Foundation
                 defer { endGenerationScope(generationScope) }
 
                 do {
-                    let context = try await loadContext(modelId: modelId, hub: hub, directory: directory)
+                    let loaded = try await loadContext(modelId: modelId, hub: hub, directory: directory)
+                    defer { withExtendedLifetime(loaded) {} }
+                    let context = loaded.context
                     guard let instructions = session.instructions?.description, !instructions.isEmpty else {
                         return
                     }
@@ -1795,6 +1808,7 @@ import Foundation
 
     private func generateStructuredJSON(
         context: ModelContext,
+        tokenCache: StructuredGenerationTokenCache,
         session: LanguageModelSession,
         prompt: Prompt,
         schema: GenerationSchema,
@@ -1829,7 +1843,7 @@ import Foundation
             endTokens: []
         )
 
-        var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: tokenCache)
         let json = try await generator.generate()
         // Ensure pending MLX operations complete before returning JSON.
         // This synchronization can be a performance cost if called frequently.

--- a/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
+++ b/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
@@ -52,6 +52,8 @@ private final class StringTokenCache: @unchecked Sendable {
     }
 
     private let tokensByKey = Locked<[Key: Set<Int>]>([:])
+    private let integerTokensByKey = Locked<[Key: Set<Int>]>([:])
+    private let decimalTokensByKey = Locked<[Key: Set<Int>]>([:])
 
     func tokens(for key: Key) -> Set<Int>? {
         tokensByKey.withLock { $0[key] }
@@ -59,6 +61,22 @@ private final class StringTokenCache: @unchecked Sendable {
 
     func store(_ tokens: Set<Int>, for key: Key) {
         tokensByKey.withLock { $0[key] = tokens }
+    }
+
+    func integerTokens(for key: Key) -> Set<Int>? {
+        integerTokensByKey.withLock { $0[key] }
+    }
+
+    func storeIntegerTokens(_ tokens: Set<Int>, for key: Key) {
+        integerTokensByKey.withLock { $0[key] = tokens }
+    }
+
+    func decimalTokens(for key: Key) -> Set<Int>? {
+        decimalTokensByKey.withLock { $0[key] }
+    }
+
+    func storeDecimalTokens(_ tokens: Set<Int>, for key: Key) {
+        decimalTokensByKey.withLock { $0[key] = tokens }
     }
 }
 
@@ -207,6 +225,11 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
     /// two tokens. Requiring every token to contain a digit excluded `-` and made negatives
     /// unrepresentable except via rare multi-character tokens.
     private static func buildValidIntegerTokens(backend: Backend) -> Set<Int> {
+        let cacheKey = stringTokenCacheKey(for: backend)
+        if let cached = StringTokenCache.shared.integerTokens(for: cacheKey) {
+            return cached
+        }
+
         var allowed = Set<Int>()
         for token in 0 ..< backend.vocabSize {
             if backend.isSpecialToken(token) { continue }
@@ -218,6 +241,8 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
                 allowed.insert(token)
             }
         }
+
+        StringTokenCache.shared.storeIntegerTokens(allowed, for: cacheKey)
         return allowed
     }
 
@@ -228,6 +253,11 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
     /// which dropped `.` and forced the model to pad zeros until `maxDecimalTokenLimit`
     /// (pathological `e+31` values after Double re-serialization).
     private static func buildValidDecimalTokens(backend: Backend) -> Set<Int> {
+        let cacheKey = stringTokenCacheKey(for: backend)
+        if let cached = StringTokenCache.shared.decimalTokens(for: cacheKey) {
+            return cached
+        }
+
         var allowed = Set<Int>()
         for token in 0 ..< backend.vocabSize {
             if backend.isSpecialToken(token) { continue }
@@ -241,6 +271,8 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
                 allowed.insert(token)
             }
         }
+
+        StringTokenCache.shared.storeDecimalTokens(allowed, for: cacheKey)
         return allowed
     }
 

--- a/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
+++ b/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
@@ -41,14 +41,16 @@ private enum OptionalStructureBudget {
     }
 }
 
-private final class StringTokenCache: @unchecked Sendable {
-    static let shared = StringTokenCache()
+private final class TokenSetCache: @unchecked Sendable {
+    static let shared = TokenSetCache()
 
     struct Key: Hashable {
         let vocabSize: Int
         let eosToken: Int
         let endTokens: Set<Int>
+        let sampleTokenIds: [Int]
         let sampleTexts: [String]
+        let sampleSpecialTokens: [Bool]
     }
 
     private let tokensByKey = Locked<[Key: Set<Int>]>([:])
@@ -126,11 +128,16 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             let token = try Self.singleToken(for: structuralText, backend: backend)
             structuralTerminators.insert(token)
         }
+        let cacheKey = Self.tokenSetCacheKey(for: backend)
         self.basicTerminators = structuralTerminators
-        self.integerTerminators = Self.buildValidIntegerTokens(backend: backend).union(structuralTerminators)
-        self.doubleTerminators = Self.buildValidDecimalTokens(backend: backend).union(structuralTerminators)
+        self.integerTerminators = Self.buildValidIntegerTokens(backend: backend, cacheKey: cacheKey).union(
+            structuralTerminators
+        )
+        self.doubleTerminators = Self.buildValidDecimalTokens(backend: backend, cacheKey: cacheKey).union(
+            structuralTerminators
+        )
 
-        let stringContentTokens = Self.buildValidStringTokens(backend: backend)
+        let stringContentTokens = Self.buildValidStringTokens(backend: backend, cacheKey: cacheKey)
         self.stringInitialAllowedTokens = stringContentTokens
         self.stringContinuationAllowedTokens = stringContentTokens.union(stringTerminators)
     }
@@ -159,9 +166,11 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
         return token
     }
 
-    private static func buildValidStringTokens(backend: Backend) -> Set<Int> {
-        let cacheKey = stringTokenCacheKey(for: backend)
-        if let cached = StringTokenCache.shared.tokens(for: cacheKey) {
+    private static func buildValidStringTokens(
+        backend: Backend,
+        cacheKey: TokenSetCache.Key
+    ) -> Set<Int> {
+        if let cached = TokenSetCache.shared.tokens(for: cacheKey) {
             return cached
         }
 
@@ -184,18 +193,20 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             }
         }
 
-        StringTokenCache.shared.store(allowed, for: cacheKey)
+        TokenSetCache.shared.store(allowed, for: cacheKey)
         return allowed
     }
 
-    private static func stringTokenCacheKey(for backend: Backend) -> StringTokenCache.Key {
+    private static func tokenSetCacheKey(for backend: Backend) -> TokenSetCache.Key {
         let sampleTokenIds = sampleTokenIds(for: backend)
         let sampleTexts = sampleTokenIds.map { backend.tokenText($0) ?? "" }
-        return StringTokenCache.Key(
+        return TokenSetCache.Key(
             vocabSize: backend.vocabSize,
             eosToken: backend.eosToken,
             endTokens: backend.endTokens,
-            sampleTexts: sampleTexts
+            sampleTokenIds: sampleTokenIds,
+            sampleTexts: sampleTexts,
+            sampleSpecialTokens: sampleTokenIds.map { backend.isSpecialToken($0) }
         )
     }
 
@@ -210,6 +221,13 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             backend.eosToken,
         ]
         samples.formUnion(backend.endTokens)
+        // Include numeric encodings so tokenizers with different digit, sign, or
+        // decimal-point mappings do not share cached token sets.
+        for text in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "-"] {
+            if let tokens = try? backend.tokenize(text) {
+                samples.formUnion(tokens)
+            }
+        }
         return samples.filter { $0 >= 0 && $0 < vocabSize }.sorted()
     }
 
@@ -224,9 +242,11 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
     /// Standalone `-` is required because BPE tokenizers (Qwen2.5, etc.) encode `-1` as
     /// two tokens. Requiring every token to contain a digit excluded `-` and made negatives
     /// unrepresentable except via rare multi-character tokens.
-    private static func buildValidIntegerTokens(backend: Backend) -> Set<Int> {
-        let cacheKey = stringTokenCacheKey(for: backend)
-        if let cached = StringTokenCache.shared.integerTokens(for: cacheKey) {
+    private static func buildValidIntegerTokens(
+        backend: Backend,
+        cacheKey: TokenSetCache.Key
+    ) -> Set<Int> {
+        if let cached = TokenSetCache.shared.integerTokens(for: cacheKey) {
             return cached
         }
 
@@ -242,7 +262,7 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             }
         }
 
-        StringTokenCache.shared.storeIntegerTokens(allowed, for: cacheKey)
+        TokenSetCache.shared.storeIntegerTokens(allowed, for: cacheKey)
         return allowed
     }
 
@@ -252,9 +272,11 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
     /// `4` `7` `3` `.` `0` `0`. The previous filter required every token to contain a digit,
     /// which dropped `.` and forced the model to pad zeros until `maxDecimalTokenLimit`
     /// (pathological `e+31` values after Double re-serialization).
-    private static func buildValidDecimalTokens(backend: Backend) -> Set<Int> {
-        let cacheKey = stringTokenCacheKey(for: backend)
-        if let cached = StringTokenCache.shared.decimalTokens(for: cacheKey) {
+    private static func buildValidDecimalTokens(
+        backend: Backend,
+        cacheKey: TokenSetCache.Key
+    ) -> Set<Int> {
+        if let cached = TokenSetCache.shared.decimalTokens(for: cacheKey) {
             return cached
         }
 
@@ -272,7 +294,7 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             }
         }
 
-        StringTokenCache.shared.storeDecimalTokens(allowed, for: cacheKey)
+        TokenSetCache.shared.storeDecimalTokens(allowed, for: cacheKey)
         return allowed
     }
 

--- a/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
+++ b/Sources/AnyLanguageModel/Shared/StructuredGeneration.swift
@@ -41,44 +41,75 @@ private enum OptionalStructureBudget {
     }
 }
 
-private final class TokenSetCache: @unchecked Sendable {
-    static let shared = TokenSetCache()
+/// Vocabulary-derived content tokens, independent of generation-specific terminators.
+struct StructuredGenerationTokenSets: Sendable {
+    let stringContent: Set<Int>
+    let integerContent: Set<Int>
+    let decimalContent: Set<Int>
 
-    struct Key: Hashable {
-        let vocabSize: Int
-        let eosToken: Int
-        let endTokens: Set<Int>
-        let sampleTokenIds: [Int]
-        let sampleTexts: [String]
-        let sampleSpecialTokens: [Bool]
+    /// Classifies all content types in one synchronous vocabulary pass.
+    init<Backend: TokenBackend>(backend: Backend) {
+        let allowedWhitespace: Set<Character> = [" ", "\t", "\n"]
+        var strings = Set<Int>()
+        var integers = Set<Int>()
+        var decimals = Set<Int>()
+        strings.reserveCapacity(backend.vocabSize / 4)
+
+        for token in 0 ..< backend.vocabSize {
+            if backend.isSpecialToken(token) { continue }
+            guard let text = backend.tokenText(token), !text.isEmpty else { continue }
+
+            if text.allSatisfy({ $0.isValidJSONStringCharacter }) {
+                if !text.allSatisfy({ $0.isWhitespace })
+                    || (text.count == 1 && text.first.map { allowedWhitespace.contains($0) } == true)
+                {
+                    strings.insert(token)
+                }
+            }
+
+            let hasDigit = text.contains { Self.isASCIIDigit($0) }
+            // Standalone signs and decimal points are needed by split numeric encodings.
+            if text.allSatisfy({ Self.isASCIIDigit($0) || $0 == "-" }),
+                hasDigit || text == "-"
+            {
+                integers.insert(token)
+            }
+            if text.allSatisfy({ Self.isASCIIDigit($0) || $0 == "-" || $0 == "." }),
+                hasDigit || text == "-" || text == "."
+            {
+                decimals.insert(token)
+            }
+        }
+
+        self.stringContent = strings
+        self.integerContent = integers
+        self.decimalContent = decimals
     }
 
-    private let tokensByKey = Locked<[Key: Set<Int>]>([:])
-    private let integerTokensByKey = Locked<[Key: Set<Int>]>([:])
-    private let decimalTokensByKey = Locked<[Key: Set<Int>]>([:])
-
-    func tokens(for key: Key) -> Set<Int>? {
-        tokensByKey.withLock { $0[key] }
+    /// JSON numbers accept ASCII digits only, not other Unicode number characters.
+    private static func isASCIIDigit(_ character: Character) -> Bool {
+        character >= "0" && character <= "9"
     }
+}
 
-    func store(_ tokens: Set<Int>, for key: Key) {
-        tokensByKey.withLock { $0[key] = tokens }
-    }
+/// Owned by one loaded tokenizer with immutable token text and special-token classification.
+/// Replacing the tokenizer or special-token registry requires a new cache; changing only
+/// end tokens does not. Vocabulary size indexes valid token-ID ranges, not tokenizer identity.
+final class StructuredGenerationTokenCache: Sendable {
+    private let tokensByVocabSize = Locked<[Int: StructuredGenerationTokenSets]>([:])
 
-    func integerTokens(for key: Key) -> Set<Int>? {
-        integerTokensByKey.withLock { $0[key] }
-    }
-
-    func storeIntegerTokens(_ tokens: Set<Int>, for key: Key) {
-        integerTokensByKey.withLock { $0[key] = tokens }
-    }
-
-    func decimalTokens(for key: Key) -> Set<Int>? {
-        decimalTokensByKey.withLock { $0[key] }
-    }
-
-    func storeDecimalTokens(_ tokens: Set<Int>, for key: Key) {
-        decimalTokensByKey.withLock { $0[key] = tokens }
+    func tokens<Backend: TokenBackend>(for backend: Backend) -> StructuredGenerationTokenSets {
+        tokensByVocabSize.withLock { entries in
+            if let tokens = entries[backend.vocabSize] {
+                return tokens
+            }
+            // Hold this owner's lock through construction and publication so concurrent
+            // first use performs one scan. Classification does no inference or async work
+            // and must not recursively access this cache. No backend is retained.
+            let tokens = StructuredGenerationTokenSets(backend: backend)
+            entries[backend.vocabSize] = tokens
+            return tokens
+        }
     }
 }
 
@@ -113,8 +144,13 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
     /// - Parameters:
     ///   - backend: A backend that provides tokenization and sampling.
     ///   - schema: The generation schema to satisfy.
+    ///   - tokenCache: The loaded tokenizer's cache, or nil to classify fresh token sets.
     /// - Throws: ``ConstrainedGenerationError`` when required tokens cannot be tokenized.
-    init(backend: Backend, schema: GenerationSchema) throws {
+    init(
+        backend: Backend,
+        schema: GenerationSchema,
+        tokenCache: StructuredGenerationTokenCache? = nil
+    ) throws {
         self.backend = backend
         self.schema = schema
 
@@ -128,16 +164,12 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             let token = try Self.singleToken(for: structuralText, backend: backend)
             structuralTerminators.insert(token)
         }
-        let cacheKey = Self.tokenSetCacheKey(for: backend)
+        let tokens = tokenCache?.tokens(for: backend) ?? StructuredGenerationTokenSets(backend: backend)
         self.basicTerminators = structuralTerminators
-        self.integerTerminators = Self.buildValidIntegerTokens(backend: backend, cacheKey: cacheKey).union(
-            structuralTerminators
-        )
-        self.doubleTerminators = Self.buildValidDecimalTokens(backend: backend, cacheKey: cacheKey).union(
-            structuralTerminators
-        )
+        self.integerTerminators = tokens.integerContent.union(structuralTerminators)
+        self.doubleTerminators = tokens.decimalContent.union(structuralTerminators)
 
-        let stringContentTokens = Self.buildValidStringTokens(backend: backend, cacheKey: cacheKey)
+        let stringContentTokens = tokens.stringContent.subtracting(backend.endTokens)
         self.stringInitialAllowedTokens = stringContentTokens
         self.stringContinuationAllowedTokens = stringContentTokens.union(stringTerminators)
     }
@@ -164,138 +196,6 @@ struct ConstrainedJSONGenerator<Backend: TokenBackend> {
             throw ConstrainedGenerationError.unsupportedTokenizer("Expected single-token encoding for '\(text)'")
         }
         return token
-    }
-
-    private static func buildValidStringTokens(
-        backend: Backend,
-        cacheKey: TokenSetCache.Key
-    ) -> Set<Int> {
-        if let cached = TokenSetCache.shared.tokens(for: cacheKey) {
-            return cached
-        }
-
-        let allowedWhitespace: Set<Character> = [" ", "\t", "\n"]
-        var allowed = Set<Int>()
-        allowed.reserveCapacity(backend.vocabSize / 4)
-
-        for token in 0 ..< backend.vocabSize {
-            if backend.endTokens.contains(token) { continue }
-            if backend.isSpecialToken(token) { continue }
-            guard let text = backend.tokenText(token), !text.isEmpty else { continue }
-            guard text.allSatisfy({ $0.isValidJSONStringCharacter }) else { continue }
-
-            if text.allSatisfy({ $0.isWhitespace }) {
-                if text.count == 1, let char = text.first, allowedWhitespace.contains(char) {
-                    allowed.insert(token)
-                }
-            } else {
-                allowed.insert(token)
-            }
-        }
-
-        TokenSetCache.shared.store(allowed, for: cacheKey)
-        return allowed
-    }
-
-    private static func tokenSetCacheKey(for backend: Backend) -> TokenSetCache.Key {
-        let sampleTokenIds = sampleTokenIds(for: backend)
-        let sampleTexts = sampleTokenIds.map { backend.tokenText($0) ?? "" }
-        return TokenSetCache.Key(
-            vocabSize: backend.vocabSize,
-            eosToken: backend.eosToken,
-            endTokens: backend.endTokens,
-            sampleTokenIds: sampleTokenIds,
-            sampleTexts: sampleTexts,
-            sampleSpecialTokens: sampleTokenIds.map { backend.isSpecialToken($0) }
-        )
-    }
-
-    private static func sampleTokenIds(for backend: Backend) -> [Int] {
-        let vocabSize = max(0, backend.vocabSize)
-        var samples: Set<Int> = [
-            0,
-            1,
-            2,
-            max(0, vocabSize / 2),
-            max(0, vocabSize - 1),
-            backend.eosToken,
-        ]
-        samples.formUnion(backend.endTokens)
-        // Include numeric encodings so tokenizers with different digit, sign, or
-        // decimal-point mappings do not share cached token sets.
-        for text in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "-"] {
-            if let tokens = try? backend.tokenize(text) {
-                samples.formUnion(tokens)
-            }
-        }
-        return samples.filter { $0 >= 0 && $0 < vocabSize }.sorted()
-    }
-
-    /// ASCII digit `0`...`9` only — JSON numbers must not accept fullwidth / superscript
-    /// forms that `Character.isNumber` would otherwise admit.
-    private static func isASCIIDigit(_ character: Character) -> Bool {
-        character >= "0" && character <= "9"
-    }
-
-    /// Tokens that may appear inside a JSON integer: ASCII digits and standalone `-`.
-    ///
-    /// Standalone `-` is required because BPE tokenizers (Qwen2.5, etc.) encode `-1` as
-    /// two tokens. Requiring every token to contain a digit excluded `-` and made negatives
-    /// unrepresentable except via rare multi-character tokens.
-    private static func buildValidIntegerTokens(
-        backend: Backend,
-        cacheKey: TokenSetCache.Key
-    ) -> Set<Int> {
-        if let cached = TokenSetCache.shared.integerTokens(for: cacheKey) {
-            return cached
-        }
-
-        var allowed = Set<Int>()
-        for token in 0 ..< backend.vocabSize {
-            if backend.isSpecialToken(token) { continue }
-            guard let text = backend.tokenText(token), !text.isEmpty else { continue }
-            let onlyIntegerChars = text.allSatisfy { Self.isASCIIDigit($0) || $0 == "-" }
-            let hasDigit = text.contains { Self.isASCIIDigit($0) }
-            let isStandaloneMinus = text == "-"
-            if onlyIntegerChars && (hasDigit || isStandaloneMinus) {
-                allowed.insert(token)
-            }
-        }
-
-        TokenSetCache.shared.storeIntegerTokens(allowed, for: cacheKey)
-        return allowed
-    }
-
-    /// Tokens that may appear inside a JSON number: ASCII digits, `-`, and `.`.
-    ///
-    /// **Critical:** standalone `.` and `-` must be included. Qwen2.5 encodes `473.00` as
-    /// `4` `7` `3` `.` `0` `0`. The previous filter required every token to contain a digit,
-    /// which dropped `.` and forced the model to pad zeros until `maxDecimalTokenLimit`
-    /// (pathological `e+31` values after Double re-serialization).
-    private static func buildValidDecimalTokens(
-        backend: Backend,
-        cacheKey: TokenSetCache.Key
-    ) -> Set<Int> {
-        if let cached = TokenSetCache.shared.decimalTokens(for: cacheKey) {
-            return cached
-        }
-
-        var allowed = Set<Int>()
-        for token in 0 ..< backend.vocabSize {
-            if backend.isSpecialToken(token) { continue }
-            guard let text = backend.tokenText(token), !text.isEmpty else { continue }
-            let onlyNumberChars = text.allSatisfy {
-                Self.isASCIIDigit($0) || $0 == "-" || $0 == "."
-            }
-            let hasDigit = text.contains { Self.isASCIIDigit($0) }
-            let isStandaloneSignOrDot = text == "-" || text == "."
-            if onlyNumberChars && (hasDigit || isStandaloneSignOrDot) {
-                allowed.insert(token)
-            }
-        }
-
-        TokenSetCache.shared.storeDecimalTokens(allowed, for: cacheKey)
-        return allowed
     }
 
     private mutating func emit(_ text: String) async throws -> String {

--- a/Tests/AnyLanguageModelTests/Shared/MockTokenBackend.swift
+++ b/Tests/AnyLanguageModelTests/Shared/MockTokenBackend.swift
@@ -4,6 +4,8 @@ import Foundation
 
 final class MockTokenCapture {
     private(set) var tokens: [Int] = []
+    var tokenTextCalls = 0
+    var specialTokenCalls = 0
     var tokenToText: [Int: String]
 
     init(tokenToText: [Int: String]) {
@@ -63,11 +65,13 @@ struct MockTokenBackend: TokenBackend {
     }
 
     func tokenText(_ token: Int) -> String? {
-        tokenToText[token]
+        capture.tokenTextCalls += 1
+        return tokenToText[token]
     }
 
     func isSpecialToken(_ token: Int) -> Bool {
-        specialTokens.contains(token)
+        capture.specialTokenCalls += 1
+        return specialTokens.contains(token)
     }
 
     mutating func decode(_ token: Int) async throws {

--- a/Tests/AnyLanguageModelTests/StructuredGenerationTests.swift
+++ b/Tests/AnyLanguageModelTests/StructuredGenerationTests.swift
@@ -851,16 +851,17 @@ struct StructuredGenerationTests {
             maximumTokens: 64
         )
         let schema = String.generationSchema
+        let cache = StructuredGenerationTokenCache()
 
-        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: cache)
         let coldTextCalls = backend.capture.tokenTextCalls
         let coldSpecialCalls = backend.capture.specialTokenCalls
-        #expect(coldTextCalls >= 3 * backend.vocabSize - 1)
-        #expect(coldSpecialCalls >= 3 * backend.vocabSize - 1)
+        #expect(coldTextCalls == backend.vocabSize)
+        #expect(coldSpecialCalls == backend.vocabSize)
 
-        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema)
-        #expect(backend.capture.tokenTextCalls - coldTextCalls < backend.vocabSize)
-        #expect(backend.capture.specialTokenCalls - coldSpecialCalls < backend.vocabSize)
+        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: cache)
+        #expect(backend.capture.tokenTextCalls == coldTextCalls)
+        #expect(backend.capture.specialTokenCalls == coldSpecialCalls)
     }
 
     @Test(arguments: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "-"])
@@ -875,8 +876,8 @@ struct StructuredGenerationTests {
         let output = numericText == "." ? "1.0" : numericText == "-" ? "-1" : numericText
 
         // Both vocabularies have identical original samples. Moving every numeric
-        // token preserves even the ordered numeric sample texts, so the key must
-        // also retain their IDs.
+        // token preserves even the ordered numeric sample texts. Each loaded
+        // tokenizer must own a separate cache.
         for offset in [60, 80] {
             var maps = baseTokenMaps()
             maps.tokenToText = maps.tokenToText.filter { !$0.value.contains(where: { "0123456789-".contains($0) }) }
@@ -894,7 +895,11 @@ struct StructuredGenerationTests {
                 maximumTokens: 64,
                 samplingQueue: queue
             )
-            var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+            var generator = try ConstrainedJSONGenerator(
+                backend: backend,
+                schema: schema,
+                tokenCache: StructuredGenerationTokenCache()
+            )
             #expect(try await generator.generate() == output)
         }
     }
@@ -918,10 +923,14 @@ struct StructuredGenerationTests {
             maximumTokens: 64,
             samplingQueue: [6, 2]
         )
-        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: StructuredGenerationTokenCache())
 
         backend.specialTokens = []
-        var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        var generator = try ConstrainedJSONGenerator(
+            backend: backend,
+            schema: schema,
+            tokenCache: StructuredGenerationTokenCache()
+        )
         #expect(try await generator.generate() == "1")
     }
 

--- a/Tests/AnyLanguageModelTests/StructuredGenerationTests.swift
+++ b/Tests/AnyLanguageModelTests/StructuredGenerationTests.swift
@@ -840,6 +840,91 @@ struct StructuredGenerationTests {
         return maps
     }
 
+    @Test func repeatedInitializationReusesAllTokenSets() throws {
+        var maps = numberTokenMaps()
+        maps.tokenToText[1000] = "<cache-reuse-eos>"
+        let backend = MockTokenBackend(
+            tokenToText: maps.tokenToText,
+            textToTokens: maps.textToTokens,
+            eosToken: 1000,
+            endTokens: [1000],
+            maximumTokens: 64
+        )
+        let schema = String.generationSchema
+
+        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        let coldTextCalls = backend.capture.tokenTextCalls
+        let coldSpecialCalls = backend.capture.specialTokenCalls
+        #expect(coldTextCalls >= 3 * backend.vocabSize - 1)
+        #expect(coldSpecialCalls >= 3 * backend.vocabSize - 1)
+
+        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        #expect(backend.capture.tokenTextCalls - coldTextCalls < backend.vocabSize)
+        #expect(backend.capture.specialTokenCalls - coldSpecialCalls < backend.vocabSize)
+    }
+
+    @Test(arguments: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "-"])
+    func numericTokenCachesDistinguishTokenMappings(numericText: String) async throws {
+        let numberNode = GenerationSchema.NumberNode(
+            description: nil,
+            minimum: nil,
+            maximum: nil,
+            integerOnly: numericText != "."
+        )
+        let schema = GenerationSchema.primitive(Double.self, node: .number(numberNode))
+        let output = numericText == "." ? "1.0" : numericText == "-" ? "-1" : numericText
+
+        // Both vocabularies have identical original samples. Moving every numeric
+        // token preserves even the ordered numeric sample texts, so the key must
+        // also retain their IDs.
+        for offset in [60, 80] {
+            var maps = baseTokenMaps()
+            maps.tokenToText = maps.tokenToText.filter { !$0.value.contains(where: { "0123456789-".contains($0) }) }
+            for (index, text) in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "-"].enumerated() {
+                maps.tokenToText[offset + index] = text
+                maps.textToTokens[text] = [offset + index]
+            }
+            maps.tokenToText[200] = "<numeric-mapping-eos>"
+            let queue = output.flatMap { maps.textToTokens[String($0)] ?? [] } + [2]
+            let backend = MockTokenBackend(
+                tokenToText: maps.tokenToText,
+                textToTokens: maps.textToTokens,
+                eosToken: 200,
+                endTokens: [200],
+                maximumTokens: 64,
+                samplingQueue: queue
+            )
+            var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+            #expect(try await generator.generate() == output)
+        }
+    }
+
+    @Test func numericTokenCachesDistinguishSpecialTokens() async throws {
+        var maps = numberTokenMaps()
+        maps.tokenToText[300] = "<numeric-special-eos>"
+        let numberNode = GenerationSchema.NumberNode(
+            description: nil,
+            minimum: nil,
+            maximum: nil,
+            integerOnly: true
+        )
+        let schema = GenerationSchema.primitive(Int.self, node: .number(numberNode))
+        var backend = MockTokenBackend(
+            tokenToText: maps.tokenToText,
+            textToTokens: maps.textToTokens,
+            specialTokens: [6],
+            eosToken: 300,
+            endTokens: [300],
+            maximumTokens: 64,
+            samplingQueue: [6, 2]
+        )
+        _ = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+
+        backend.specialTokens = []
+        var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema)
+        #expect(try await generator.generate() == "1")
+    }
+
     @Test func decimalNumberEmitsStandaloneDot() async throws {
         // Qwen2.5-style tokenization of 473.00 is 4 7 3 . 0 0. Standalone `.` must be
         // in the decimal mask; otherwise the model cannot place the point and pads digits

--- a/Tests/AnyLanguageModelTests/StructuredGenerationTokenCacheTests.swift
+++ b/Tests/AnyLanguageModelTests/StructuredGenerationTokenCacheTests.swift
@@ -1,0 +1,341 @@
+import Testing
+
+@testable import AnyLanguageModel
+
+struct StructuredGenerationTokenCacheTests {
+    /// Immutable vocabulary and synchronized observations, safe to share across tasks.
+    private struct VocabularyBackend: TokenBackend, Sendable {
+        struct Observations: Sendable {
+            var textCalls: [Int: Int] = [:]
+            var specialCalls: [Int: Int] = [:]
+            var masks: [Set<Int>] = []
+        }
+
+        let texts: [Int: String]
+        let specialTokens: Set<Int>
+        let vocabSize: Int
+        let observations = Locked(Observations())
+        var endTokens: Set<Int> = [63]
+        var eosToken: Int { 63 }
+        var remainingTokens = 64
+        var totalTokenBudget: Int { 64 }
+        var queue: [Int] = []
+
+        init(texts: [Int: String], specialTokens: Set<Int> = [], vocabSize: Int = 64) {
+            self.texts = texts
+            self.specialTokens = specialTokens
+            self.vocabSize = vocabSize
+        }
+
+        func tokenize(_ text: String) throws -> [Int] {
+            texts.first { $0.value == text }.map { [$0.key] } ?? []
+        }
+
+        func tokenText(_ token: Int) -> String? {
+            observations.withLock { $0.textCalls[token, default: 0] += 1 }
+            return texts[token]
+        }
+
+        func isSpecialToken(_ token: Int) -> Bool {
+            observations.withLock { $0.specialCalls[token, default: 0] += 1 }
+            return specialTokens.contains(token)
+        }
+
+        mutating func decode(_ token: Int) async throws {
+            remainingTokens -= 1
+        }
+
+        mutating func sample(from allowedTokens: Set<Int>) async throws -> Int {
+            observations.withLock { $0.masks.append(allowedTokens) }
+            guard !queue.isEmpty else { throw ConstrainedGenerationError.tokenizationFailed }
+            let token = queue.removeFirst()
+            guard allowedTokens.contains(token) else { throw ConstrainedGenerationError.tokenizationFailed }
+            return token
+        }
+    }
+
+    private var baseTexts: [Int: String] {
+        var texts = [0: "\"", 1: ",", 2: "}", 3: "]", 4: ":", 15: "-", 16: ".", 63: "<eos>"]
+        for digit in 0 ... 9 { texts[5 + digit] = String(digit) }
+        return texts
+    }
+
+    private func expectEqual(_ lhs: StructuredGenerationTokenSets, _ rhs: StructuredGenerationTokenSets) {
+        #expect(lhs.stringContent == rhs.stringContent)
+        #expect(lhs.integerContent == rhs.integerContent)
+        #expect(lhs.decimalContent == rhs.decimalContent)
+    }
+
+    @Test func coldConstructionClassifiesAllSetsInOnePass() {
+        let backend = VocabularyBackend(
+            texts: [0: "word", 1: "42", 2: "-", 3: ".", 4: "-1.5", 5: "", 6: "9", 7: "\""],
+            specialTokens: [6],
+            vocabSize: 9
+        )
+        let tokens = StructuredGenerationTokenCache().tokens(for: backend)
+        #expect(tokens.stringContent == [0, 1, 2, 3, 4])
+        #expect(tokens.integerContent == [1, 2])
+        #expect(tokens.decimalContent == [1, 2, 3, 4])
+        let observations = backend.observations.withLock { $0 }
+        #expect(observations.specialCalls == Dictionary(uniqueKeysWithValues: (0 ..< 9).map { ($0, 1) }))
+        #expect(observations.textCalls == [0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 7: 1, 8: 1])
+    }
+
+    private struct ClassificationCase: Sendable {
+        let text: String?
+        var special = false
+        var string = false
+        var integer = false
+        var decimal = false
+    }
+
+    @Test(arguments: [
+        ClassificationCase(text: nil),
+        ClassificationCase(text: ""),
+        ClassificationCase(text: "42", special: true),
+        ClassificationCase(text: "42", string: true, integer: true, decimal: true),
+        ClassificationCase(text: "-12", string: true, integer: true, decimal: true),
+        ClassificationCase(text: "-", string: true, integer: true, decimal: true),
+        ClassificationCase(text: ".", string: true, decimal: true),
+        ClassificationCase(text: "12.5", string: true, decimal: true),
+        ClassificationCase(text: "--", string: true),
+        ClassificationCase(text: "-.", string: true),
+        ClassificationCase(text: "1-2", string: true, integer: true, decimal: true),
+        ClassificationCase(text: "1..2", string: true, decimal: true),
+        ClassificationCase(text: "１２", string: true),
+        ClassificationCase(text: "²", string: true),
+        ClassificationCase(text: "١", string: true),
+        ClassificationCase(text: "1e2", string: true),
+        ClassificationCase(text: "+1", string: true),
+        ClassificationCase(text: " ", string: true),
+        ClassificationCase(text: "  "),
+        ClassificationCase(text: "\t"),
+        ClassificationCase(text: "\n"),
+        ClassificationCase(text: "\r"),
+        ClassificationCase(text: "\u{00A0}"),
+        ClassificationCase(text: " a ", string: true),
+        ClassificationCase(text: "a\nb"),
+        ClassificationCase(text: "\""),
+        ClassificationCase(text: "“"),
+        ClassificationCase(text: "’"),
+        ClassificationCase(text: "\\"),
+        ClassificationCase(text: "\\n"),
+        ClassificationCase(text: "】"),
+        ClassificationCase(text: "hello", string: true),
+        ClassificationCase(text: "é", string: true),
+        ClassificationCase(text: "😀", string: true),
+    ])
+    private func classifierPreservesExistingPolicy(testCase: ClassificationCase) {
+        let backend = VocabularyBackend(
+            texts: testCase.text.map { [0: $0] } ?? [:],
+            specialTokens: testCase.special ? [0] : [],
+            vocabSize: 1
+        )
+        let tokens = StructuredGenerationTokenCache().tokens(for: backend)
+        #expect(tokens.stringContent == (testCase.string ? [0] : []))
+        #expect(tokens.integerContent == (testCase.integer ? [0] : []))
+        #expect(tokens.decimalContent == (testCase.decimal ? [0] : []))
+    }
+
+    @Test func noCacheBuildsFreshSetsAndGeneratesCorrectOutput() async throws {
+        var backend = VocabularyBackend(texts: baseTexts)
+        backend.queue = [6, 2]
+        for pass in 1 ... 2 {
+            var generator = try ConstrainedJSONGenerator(backend: backend, schema: Int.generationSchema)
+            #expect(backend.observations.withLock { $0.specialCalls.values.reduce(0, +) } == pass * 64)
+            // Each preceding generation reads the emitted numeric token once.
+            #expect(backend.observations.withLock { $0.textCalls.values.reduce(0, +) } == pass * 64 + pass - 1)
+            #expect(try await generator.generate() == "1")
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func unsampledNumericDifferenceIsIndependent(reverse: Bool) async throws {
+        // Token 20 is absent from the former endpoint, midpoint, EOS, end-token,
+        // and individual digit/sign/point samples. All those mappings agree.
+        for numeric in (reverse ? [true, false] : [false, true]) {
+            var texts = baseTexts
+            texts[20] = numeric ? "42" : "word"
+            var backend = VocabularyBackend(texts: texts)
+            backend.queue = numeric ? [20, 2] : [6, 2]
+            let cache = StructuredGenerationTokenCache()
+            let tokens = cache.tokens(for: backend)
+            #expect(tokens.integerContent == Set(5 ... 15).union(numeric ? [20] : []))
+            #expect(tokens.decimalContent == Set(5 ... 16).union(numeric ? [20] : []))
+            for schema in [Int.generationSchema, Double.generationSchema] {
+                var generator = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: cache)
+                #expect(try await generator.generate() == (numeric ? "42" : "1"))
+            }
+            #expect(backend.observations.withLock { $0.masks.allSatisfy { $0.contains(20) == numeric } })
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func unsampledStringDifferenceIsIndependent(reverse: Bool) async throws {
+        for valid in (reverse ? [true, false] : [false, true]) {
+            var texts = baseTexts
+            texts[20] = valid ? "word" : "\\"
+            var backend = VocabularyBackend(texts: texts, specialTokens: [63])
+            backend.queue = [6, 0]
+            let cache = StructuredGenerationTokenCache()
+            let tokens = cache.tokens(for: backend)
+            #expect(tokens.stringContent == Set(1 ... 16).union(valid ? [20] : []))
+            var generator = try ConstrainedJSONGenerator(
+                backend: backend,
+                schema: String.generationSchema,
+                tokenCache: cache
+            )
+            #expect(try await generator.generate() == "\"1\"")
+            #expect(backend.observations.withLock { $0.masks.allSatisfy { $0.contains(20) == valid } })
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func specialTokenClassificationBelongsToLoadedVocabulary(reverse: Bool) {
+        for special in (reverse ? [true, false] : [false, true]) {
+            let backend = VocabularyBackend(texts: [20: "42"], specialTokens: special ? [20] : [])
+            let tokens = StructuredGenerationTokenCache().tokens(for: backend)
+            #expect(tokens.stringContent == (special ? [] : [20]))
+            #expect(tokens.integerContent == (special ? [] : [20]))
+            #expect(tokens.decimalContent == (special ? [] : [20]))
+        }
+    }
+
+    @Test func endTokenChangesReuseContentAndApplyCurrentMasks() async throws {
+        var texts = baseTexts
+        texts[20] = "word"
+        let original = VocabularyBackend(texts: texts, specialTokens: [63])
+        let cache = StructuredGenerationTokenCache()
+        for ends: Set<Int> in [[20, 6], [63]] {
+            var backend = original
+            backend.endTokens = ends
+            backend.queue = [7, 0]
+            var generator = try ConstrainedJSONGenerator(
+                backend: backend,
+                schema: String.generationSchema,
+                tokenCache: cache
+            )
+            #expect(try await generator.generate() == "\"2\"")
+            let masks = backend.observations.withLock { Array($0.masks.suffix(2)) }
+            let expectedInitial = Set(1 ... 16).union([20]).subtracting(ends)
+            #expect(masks[0] == expectedInitial)
+            #expect(masks[1] == expectedInitial.union(ends).union([0]))
+
+            for schema in [Int.generationSchema, Double.generationSchema] {
+                backend.queue = [7, 2]
+                var number = try ConstrainedJSONGenerator(backend: backend, schema: schema, tokenCache: cache)
+                #expect(try await number.generate() == "2")
+                // Numeric masks preserve end tokens if their content is numeric.
+                #expect(backend.observations.withLock { $0.masks.suffix(2).allSatisfy { $0.contains(6) } })
+            }
+        }
+        #expect(original.observations.withLock { $0.specialCalls.values.reduce(0, +) } == 64)
+        #expect(original.observations.withLock { $0.textCalls.values.reduce(0, +) } == 69)
+    }
+
+    @Test func vocabularySizesHaveSeparateEntries() {
+        let cache = StructuredGenerationTokenCache()
+        let small = VocabularyBackend(texts: [0: "42", 2: "1.5"], vocabSize: 2)
+        let large = VocabularyBackend(texts: small.texts, vocabSize: 3)
+        let first = cache.tokens(for: small)
+        #expect(first.stringContent == [0])
+        #expect(first.integerContent == [0])
+        #expect(first.decimalContent == [0])
+        let second = cache.tokens(for: large)
+        #expect(second.stringContent == [0, 2])
+        #expect(second.integerContent == [0])
+        #expect(second.decimalContent == [0, 2])
+        expectEqual(cache.tokens(for: small), first)
+        #expect(small.observations.withLock { $0.specialCalls == [0: 1, 1: 1] })
+        #expect(large.observations.withLock { $0.specialCalls == [0: 1, 1: 1, 2: 1] })
+    }
+
+    @Test func concurrentFirstUsePerformsExactlyOneScan() async {
+        let backend = VocabularyBackend(texts: [20: "42", 21: "."], specialTokens: [63])
+        let cache = StructuredGenerationTokenCache()
+        await withTaskGroup(of: StructuredGenerationTokenSets.self) { group in
+            for _ in 0 ..< 32 {
+                group.addTask { cache.tokens(for: backend) }
+            }
+            for await tokens in group {
+                #expect(tokens.stringContent == [20, 21])
+                #expect(tokens.integerContent == [20])
+                #expect(tokens.decimalContent == [20, 21])
+            }
+        }
+        #expect(
+            backend.observations.withLock { $0.specialCalls }
+                == Dictionary(
+                    uniqueKeysWithValues: (0 ..< 64).map { ($0, 1) }
+                )
+        )
+        #expect(
+            backend.observations.withLock { $0.textCalls }
+                == Dictionary(
+                    uniqueKeysWithValues: (0 ..< 63).map { ($0, 1) }
+                )
+        )
+    }
+
+    @Test func reloadCreatesFreshCacheAndActiveOwnershipControlsRelease() throws {
+        struct LoadedOwner {
+            let label = "same-model"
+            let backend: VocabularyBackend
+            let cache = StructuredGenerationTokenCache()
+        }
+        var loaded: LoadedOwner? = LoadedOwner(backend: VocabularyBackend(texts: [20: "42"]))
+        var activeRequest = loaded
+        weak var oldCache: StructuredGenerationTokenCache?
+        oldCache = loaded?.cache
+        do {
+            let initial = try #require(loaded)
+            #expect(initial.cache.tokens(for: initial.backend).integerContent == [20])
+            loaded = LoadedOwner(backend: VocabularyBackend(texts: [20: "word"]))
+            let reloaded = try #require(loaded)
+            #expect(reloaded.label == initial.label)
+            #expect(reloaded.cache !== initial.cache)
+            #expect(reloaded.cache.tokens(for: reloaded.backend).integerContent.isEmpty)
+        }
+        #expect(oldCache != nil)
+        #expect(activeRequest?.cache === oldCache)
+        do {
+            let active = try #require(activeRequest)
+            #expect(active.cache.tokens(for: active.backend).integerContent == [20])
+            #expect(active.backend.observations.withLock { $0.specialCalls.values.reduce(0, +) } == 64)
+        }
+        activeRequest = nil
+        #expect(oldCache == nil)
+        withExtendedLifetime(loaded) {}
+    }
+
+    @Test func cacheDoesNotRetainBackendOrOutliveOwner() {
+        weak var releasedCache: StructuredGenerationTokenCache?
+        weak var releasedObservations: Locked<VocabularyBackend.Observations>?
+        var activeCache: StructuredGenerationTokenCache?
+        do {
+            let backend = VocabularyBackend(texts: [20: "42"])
+            let cache = StructuredGenerationTokenCache()
+            releasedCache = cache
+            releasedObservations = backend.observations
+            _ = cache.tokens(for: backend)
+            activeCache = cache
+        }
+        #expect(releasedObservations == nil)
+        #expect(releasedCache != nil)
+        withExtendedLifetime(activeCache) {}
+        activeCache = nil
+        #expect(releasedCache == nil)
+    }
+
+    @Test func structuralValidationPrecedesScanning() {
+        let backend = VocabularyBackend(texts: [0: "\"", 1: ","])
+        #expect(throws: ConstrainedGenerationError.self) {
+            _ = try ConstrainedJSONGenerator(
+                backend: backend,
+                schema: String.generationSchema,
+                tokenCache: StructuredGenerationTokenCache()
+            )
+        }
+        #expect(backend.observations.withLock { $0.textCalls.isEmpty && $0.specialCalls.isEmpty })
+    }
+}


### PR DESCRIPTION
Repeated structured generations currently rescan numeric token sets, and the shared sampled cache key can also reuse incorrect masks when two tokenizers differ at an unsampled token. For example, an unsampled token mapped to `42` in one vocabulary and ordinary text in another must have different numeric eligibility.

This PR updates this logic to cache string, integer, and decimal content together in one synchronous vocabulary pass, owned by each loaded model/tokenizer.