### PR TITLE
Preserve Gemini tool arguments and text thought signatures

### DIFF
--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -200,7 +200,6 @@ public final class LanguageModelSession: @unchecked Sendable {
         public let rawContent: GeneratedContent
         public let transcriptEntries: ArraySlice<Transcript.Entry>
 
-        /// Opaque, provider-specific state to preserve on the transcript response.
         internal let providerMetadata: [String: String]?
 
         /// Creates a response value from generated content and transcript entries.
@@ -866,7 +865,6 @@ extension LanguageModelSession {
             /// Cumulative across tool rounds; empty for providers that don't stream tool activity.
             public var transcriptEntries: ArraySlice<Transcript.Entry>
 
-            /// Opaque, provider-specific state accumulated for the response so far.
             internal var providerMetadata: [String: String]?
 
             /// Creates a snapshot from partially generated content and raw content.

--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -201,19 +201,31 @@ public final class LanguageModelSession: @unchecked Sendable {
         public let transcriptEntries: ArraySlice<Transcript.Entry>
 
         /// Opaque, provider-specific state to preserve on the transcript response.
-        public let providerMetadata: [String: String]?
+        internal let providerMetadata: [String: String]?
 
         /// Creates a response value from generated content and transcript entries.
         /// - Parameters:
         ///   - content: The decoded response content.
         ///   - rawContent: The raw content produced by the model.
         ///   - transcriptEntries: Transcript entries associated with the response.
-        ///   - providerMetadata: Opaque state to preserve when replaying the response.
         public init(
             content: Content,
             rawContent: GeneratedContent,
+            transcriptEntries: ArraySlice<Transcript.Entry>
+        ) {
+            self.init(
+                content: content,
+                rawContent: rawContent,
+                transcriptEntries: transcriptEntries,
+                providerMetadata: nil
+            )
+        }
+
+        internal init(
+            content: Content,
+            rawContent: GeneratedContent,
             transcriptEntries: ArraySlice<Transcript.Entry>,
-            providerMetadata: [String: String]? = nil
+            providerMetadata: [String: String]?
         ) {
             self.content = content
             self.rawContent = rawContent
@@ -855,19 +867,31 @@ extension LanguageModelSession {
             public var transcriptEntries: ArraySlice<Transcript.Entry>
 
             /// Opaque, provider-specific state accumulated for the response so far.
-            public var providerMetadata: [String: String]?
+            internal var providerMetadata: [String: String]?
 
             /// Creates a snapshot from partially generated content and raw content.
             /// - Parameters:
             ///   - content: The partially generated content.
             ///   - rawContent: The raw content produced by the model.
             ///   - transcriptEntries: Transcript entries accumulated so far (tool calls/outputs).
-            ///   - providerMetadata: Opaque state to preserve when replaying the response.
             public init(
                 content: Content.PartiallyGenerated,
                 rawContent: GeneratedContent,
+                transcriptEntries: ArraySlice<Transcript.Entry> = []
+            ) {
+                self.init(
+                    content: content,
+                    rawContent: rawContent,
+                    transcriptEntries: transcriptEntries,
+                    providerMetadata: nil
+                )
+            }
+
+            internal init(
+                content: Content.PartiallyGenerated,
+                rawContent: GeneratedContent,
                 transcriptEntries: ArraySlice<Transcript.Entry> = [],
-                providerMetadata: [String: String]? = nil
+                providerMetadata: [String: String]?
             ) {
                 self.content = content
                 self.rawContent = rawContent

--- a/Sources/AnyLanguageModel/LanguageModelSession.swift
+++ b/Sources/AnyLanguageModel/LanguageModelSession.swift
@@ -168,7 +168,8 @@ public final class LanguageModelSession: @unchecked Sendable {
                         let responseEntry = Transcript.Entry.response(
                             Transcript.Response(
                                 assetIDs: [],
-                                segments: [.text(.init(content: textContent))]
+                                segments: [.text(.init(content: textContent))],
+                                providerMetadata: lastSnapshot.providerMetadata
                             )
                         )
                         session.withMutation(keyPath: \.transcript) {
@@ -199,19 +200,25 @@ public final class LanguageModelSession: @unchecked Sendable {
         public let rawContent: GeneratedContent
         public let transcriptEntries: ArraySlice<Transcript.Entry>
 
+        /// Opaque, provider-specific state to preserve on the transcript response.
+        public let providerMetadata: [String: String]?
+
         /// Creates a response value from generated content and transcript entries.
         /// - Parameters:
         ///   - content: The decoded response content.
         ///   - rawContent: The raw content produced by the model.
         ///   - transcriptEntries: Transcript entries associated with the response.
+        ///   - providerMetadata: Opaque state to preserve when replaying the response.
         public init(
             content: Content,
             rawContent: GeneratedContent,
-            transcriptEntries: ArraySlice<Transcript.Entry>
+            transcriptEntries: ArraySlice<Transcript.Entry>,
+            providerMetadata: [String: String]? = nil
         ) {
             self.content = content
             self.rawContent = rawContent
             self.transcriptEntries = transcriptEntries
+            self.providerMetadata = providerMetadata
         }
     }
 
@@ -254,7 +261,8 @@ public final class LanguageModelSession: @unchecked Sendable {
             let responseEntry = Transcript.Entry.response(
                 Transcript.Response(
                     assetIDs: [],
-                    segments: [.text(.init(content: textContent))]
+                    segments: [.text(.init(content: textContent))],
+                    providerMetadata: response.providerMetadata
                 )
             )
 
@@ -606,7 +614,8 @@ extension LanguageModelSession {
             let responseEntry = Transcript.Entry.response(
                 Transcript.Response(
                     assetIDs: [],
-                    segments: [.text(.init(content: textContent))]
+                    segments: [.text(.init(content: textContent))],
+                    providerMetadata: response.providerMetadata
                 )
             )
 
@@ -845,19 +854,25 @@ extension LanguageModelSession {
             /// Cumulative across tool rounds; empty for providers that don't stream tool activity.
             public var transcriptEntries: ArraySlice<Transcript.Entry>
 
+            /// Opaque, provider-specific state accumulated for the response so far.
+            public var providerMetadata: [String: String]?
+
             /// Creates a snapshot from partially generated content and raw content.
             /// - Parameters:
             ///   - content: The partially generated content.
             ///   - rawContent: The raw content produced by the model.
             ///   - transcriptEntries: Transcript entries accumulated so far (tool calls/outputs).
+            ///   - providerMetadata: Opaque state to preserve when replaying the response.
             public init(
                 content: Content.PartiallyGenerated,
                 rawContent: GeneratedContent,
-                transcriptEntries: ArraySlice<Transcript.Entry> = []
+                transcriptEntries: ArraySlice<Transcript.Entry> = [],
+                providerMetadata: [String: String]? = nil
             ) {
                 self.content = content
                 self.rawContent = rawContent
                 self.transcriptEntries = transcriptEntries
+                self.providerMetadata = providerMetadata
             }
         }
     }
@@ -920,7 +935,8 @@ extension LanguageModelSession.ResponseStream: AsyncSequence {
                 return LanguageModelSession.Response(
                     content: finalContent,
                     rawContent: last.rawContent,
-                    transcriptEntries: last.transcriptEntries
+                    transcriptEntries: last.transcriptEntries,
+                    providerMetadata: last.providerMetadata
                 )
             }
         }
@@ -935,7 +951,8 @@ extension LanguageModelSession.ResponseStream: AsyncSequence {
             return LanguageModelSession.Response(
                 content: finalContent,
                 rawContent: fallbackSnapshot.rawContent,
-                transcriptEntries: fallbackSnapshot.transcriptEntries
+                transcriptEntries: fallbackSnapshot.transcriptEntries,
+                providerMetadata: fallbackSnapshot.providerMetadata
             )
         }
 

--- a/Sources/AnyLanguageModel/Models/GeminiLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/GeminiLanguageModel.swift
@@ -994,8 +994,9 @@ private struct GeminiTextHistoryPart: Codable {
     let part: GeminiTextPart
 }
 
-/// Keep signed text on its original part, including unsigned siblings and their order relative
-/// to function calls. Call arguments remain in the transcript's semantic representation.
+// Keep signed text on its original part,
+// including unsigned siblings and their order relative to function calls.
+// Call arguments remain in the transcript's semantic representation.
 private func textPartMetadata(_ parts: [GeminiPart]) throws -> [String: String]? {
     let textParts = parts.enumerated().compactMap { index, part -> GeminiTextHistoryPart? in
         guard case .text(let text) = part else { return nil }

--- a/Sources/AnyLanguageModel/Models/GeminiLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/GeminiLanguageModel.swift
@@ -310,6 +310,7 @@ public struct GeminiLanguageModel: LanguageModel {
                 throw GeminiError.noCandidate
             }
 
+            let providerMetadata = try textPartMetadata(firstCandidate.content.parts ?? [])
             let functionCalls: [GeminiFunctionCall] =
                 firstCandidate.content.parts?.compactMap { part in
                     if case .functionCall(let call) = part { return call }
@@ -322,7 +323,7 @@ public struct GeminiLanguageModel: LanguageModel {
                 switch resolution {
                 case .stop(let calls):
                     if !calls.isEmpty {
-                        entries.append(.toolCalls(Transcript.ToolCalls(calls)))
+                        entries.append(.toolCalls(Transcript.ToolCalls(calls, providerMetadata: providerMetadata)))
                     }
                     let empty = try emptyResponseContent(for: type)
                     return LanguageModelSession.Response(
@@ -333,7 +334,7 @@ public struct GeminiLanguageModel: LanguageModel {
                 case .invocations(let invocations):
                     if !invocations.isEmpty {
                         let calls = Transcript.Entry.toolCalls(
-                            Transcript.ToolCalls(invocations.map(\.call))
+                            Transcript.ToolCalls(invocations.map(\.call), providerMetadata: providerMetadata)
                         )
                         transcript.append(calls)
                         entries.append(calls)
@@ -362,7 +363,8 @@ public struct GeminiLanguageModel: LanguageModel {
                     return LanguageModelSession.Response(
                         content: text as! Content,
                         rawContent: GeneratedContent(text),
-                        transcriptEntries: ArraySlice(entries)
+                        transcriptEntries: ArraySlice(entries),
+                        providerMetadata: providerMetadata
                     )
                 }
 
@@ -371,7 +373,8 @@ public struct GeminiLanguageModel: LanguageModel {
                 return LanguageModelSession.Response(
                     content: content,
                     rawContent: generatedContent,
-                    transcriptEntries: ArraySlice(entries)
+                    transcriptEntries: ArraySlice(entries),
+                    providerMetadata: providerMetadata
                 )
             }
         }
@@ -426,6 +429,7 @@ public struct GeminiLanguageModel: LanguageModel {
                         )
 
                     var accumulatedText = ""
+                    var accumulatedParts: [GeminiPart] = []
 
                     for try await chunk in stream {
                         guard let candidate = chunk.candidates.first else { continue }
@@ -434,6 +438,7 @@ public struct GeminiLanguageModel: LanguageModel {
                             for part in parts {
                                 if case .text(let textPart) = part {
                                     accumulatedText += textPart.text
+                                    accumulatedParts.append(part)
 
                                     var raw: GeneratedContent
                                     let content: Content.PartiallyGenerated?
@@ -454,7 +459,13 @@ public struct GeminiLanguageModel: LanguageModel {
                                     }
 
                                     if let content {
-                                        continuation.yield(.init(content: content, rawContent: raw))
+                                        continuation.yield(
+                                            .init(
+                                                content: content,
+                                                rawContent: raw,
+                                                providerMetadata: try textPartMetadata(accumulatedParts)
+                                            )
+                                        )
                                     }
                                 }
                             }
@@ -734,7 +745,7 @@ private func toGeneratedContent(_ value: [String: JSONValue]?) throws -> Generat
 }
 
 private func fromGeneratedContent(_ content: GeneratedContent) throws -> [String: JSONValue] {
-    let data = try JSONEncoder().encode(content)
+    let data = Data(content.jsonString.utf8)
     let jsonValue = try JSONDecoder().decode(JSONValue.self, from: data)
 
     guard case .object(let dict) = jsonValue else {
@@ -790,7 +801,8 @@ extension Transcript {
                 messages.append(
                     .init(
                         role: .model,
-                        parts: convertSegmentsToGeminiParts(response.segments)
+                        parts: restoreTextParts(from: response.providerMetadata)
+                            ?? convertSegmentsToGeminiParts(response.segments)
                     )
                 )
             case .toolCalls(let toolCalls):
@@ -808,7 +820,8 @@ extension Transcript {
                 messages.append(
                     .init(
                         role: .model,
-                        parts: functionCallParts
+                        parts: restoreTextParts(from: toolCalls.providerMetadata, around: functionCallParts)
+                            ?? functionCallParts
                     )
                 )
             case .toolOutput(let toolOutput):
@@ -901,6 +914,7 @@ private enum GeminiPart: Codable, Sendable {
         case functionCall
         case functionResponse
         case thoughtSignature
+        case thought
         case inlineData
         case fileData
     }
@@ -910,7 +924,13 @@ private enum GeminiPart: Codable, Sendable {
 
         if container.contains(.text) {
             let text = try container.decode(String.self, forKey: .text)
-            self = .text(GeminiTextPart(text: text))
+            self = .text(
+                GeminiTextPart(
+                    text: text,
+                    thoughtSignature: try container.decodeIfPresent(String.self, forKey: .thoughtSignature),
+                    thought: try container.decodeIfPresent(Bool.self, forKey: .thought)
+                )
+            )
         } else if container.contains(.functionCall) {
             // `thoughtSignature` is a sibling of `functionCall` within the part, not a member of it.
             // Thinking models require it to be echoed back verbatim, so it travels with the call.
@@ -923,6 +943,14 @@ private enum GeminiPart: Codable, Sendable {
             self = .inlineData(try container.decode(GeminiInlineData.self, forKey: .inlineData))
         } else if container.contains(.fileData) {
             self = .fileData(try container.decode(GeminiFileData.self, forKey: .fileData))
+        } else if container.contains(.thoughtSignature) {
+            // Streaming may deliver a signature in a final part without text.
+            self = .text(
+                GeminiTextPart(
+                    text: "",
+                    thoughtSignature: try container.decode(String.self, forKey: .thoughtSignature)
+                )
+            )
         } else {
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -938,6 +966,8 @@ private enum GeminiPart: Codable, Sendable {
         switch self {
         case .text(let part):
             try container.encode(part.text, forKey: .text)
+            try container.encodeIfPresent(part.thoughtSignature, forKey: .thoughtSignature)
+            try container.encodeIfPresent(part.thought, forKey: .thought)
         case .functionCall(let call):
             try container.encode(call, forKey: .functionCall)
             try container.encodeIfPresent(call.thoughtSignature, forKey: .thoughtSignature)
@@ -953,6 +983,42 @@ private enum GeminiPart: Codable, Sendable {
 
 private struct GeminiTextPart: Codable, Sendable {
     let text: String
+    var thoughtSignature: String? = nil
+    var thought: Bool? = nil
+}
+
+private let textPartsMetadataKey = "gemini.textParts"
+
+private struct GeminiTextHistoryPart: Codable {
+    let index: Int
+    let part: GeminiTextPart
+}
+
+/// Keep signed text on its original part, including unsigned siblings and their order relative
+/// to function calls. Call arguments remain in the transcript's semantic representation.
+private func textPartMetadata(_ parts: [GeminiPart]) throws -> [String: String]? {
+    let textParts = parts.enumerated().compactMap { index, part -> GeminiTextHistoryPart? in
+        guard case .text(let text) = part else { return nil }
+        return GeminiTextHistoryPart(index: index, part: text)
+    }
+    guard textParts.contains(where: { $0.part.thoughtSignature != nil }) else { return nil }
+    let data = try JSONEncoder().encode(textParts)
+    return [textPartsMetadataKey: String(decoding: data, as: UTF8.self)]
+}
+
+private func restoreTextParts(
+    from metadata: [String: String]?,
+    around functionCalls: [GeminiPart] = []
+) -> [GeminiPart]? {
+    guard let json = metadata?[textPartsMetadataKey],
+        let textParts = try? JSONDecoder().decode([GeminiTextHistoryPart].self, from: Data(json.utf8))
+    else { return nil }
+    var parts = functionCalls
+    for text in textParts {
+        guard (0 ... parts.count).contains(text.index) else { return nil }
+        parts.insert(.text(text.part), at: text.index)
+    }
+    return parts
 }
 
 private struct GeminiInlineData: Codable, Sendable {

--- a/Sources/AnyLanguageModel/Transcript.swift
+++ b/Sources/AnyLanguageModel/Transcript.swift
@@ -315,15 +315,18 @@ public struct Transcript: Sendable, Equatable, Codable {
         private var calls: [ToolCall]
 
         /// Opaque, provider-specific state attached to the model turn containing these calls.
-        /// Preserve this state when saving or replaying a transcript.
-        ///
-        /// - Note: This property is exclusive to AnyLanguageModel
-        public var providerMetadata: [String: String]?
+        /// Synthesized Codable preserves this state when saving or replaying a transcript.
+        internal var providerMetadata: [String: String]?
 
-        public init<S>(
+        public init<S>(id: String = UUID().uuidString, _ calls: S)
+        where S: Sequence, S.Element == ToolCall {
+            self.init(id: id, calls, providerMetadata: nil)
+        }
+
+        internal init<S>(
             id: String = UUID().uuidString,
             _ calls: S,
-            providerMetadata: [String: String]? = nil
+            providerMetadata: [String: String]?
         ) where S: Sequence, S.Element == ToolCall {
             self.id = id
             self.calls = Array(calls)
@@ -395,16 +398,22 @@ public struct Transcript: Sendable, Equatable, Codable {
         public var segments: [Segment]
 
         /// Opaque, provider-specific state attached to this response.
-        /// Preserve this state when saving or replaying a transcript.
-        ///
-        /// - Note: This property is exclusive to AnyLanguageModel
-        public var providerMetadata: [String: String]?
+        /// Synthesized Codable preserves this state when saving or replaying a transcript.
+        internal var providerMetadata: [String: String]?
 
         public init(
             id: String = UUID().uuidString,
             assetIDs: [String],
+            segments: [Segment]
+        ) {
+            self.init(id: id, assetIDs: assetIDs, segments: segments, providerMetadata: nil)
+        }
+
+        internal init(
+            id: String = UUID().uuidString,
+            assetIDs: [String],
             segments: [Segment],
-            providerMetadata: [String: String]? = nil
+            providerMetadata: [String: String]?
         ) {
             self.id = id
             self.assetIDs = assetIDs

--- a/Sources/AnyLanguageModel/Transcript.swift
+++ b/Sources/AnyLanguageModel/Transcript.swift
@@ -314,10 +314,20 @@ public struct Transcript: Sendable, Equatable, Codable {
 
         private var calls: [ToolCall]
 
-        public init<S>(id: String = UUID().uuidString, _ calls: S)
-        where S: Sequence, S.Element == ToolCall {
+        /// Opaque, provider-specific state attached to the model turn containing these calls.
+        /// Preserve this state when saving or replaying a transcript.
+        ///
+        /// - Note: This property is exclusive to AnyLanguageModel
+        public var providerMetadata: [String: String]?
+
+        public init<S>(
+            id: String = UUID().uuidString,
+            _ calls: S,
+            providerMetadata: [String: String]? = nil
+        ) where S: Sequence, S.Element == ToolCall {
             self.id = id
             self.calls = Array(calls)
+            self.providerMetadata = providerMetadata
         }
     }
 
@@ -384,14 +394,22 @@ public struct Transcript: Sendable, Equatable, Codable {
         /// Ordered prompt segments.
         public var segments: [Segment]
 
+        /// Opaque, provider-specific state attached to this response.
+        /// Preserve this state when saving or replaying a transcript.
+        ///
+        /// - Note: This property is exclusive to AnyLanguageModel
+        public var providerMetadata: [String: String]?
+
         public init(
             id: String = UUID().uuidString,
             assetIDs: [String],
-            segments: [Segment]
+            segments: [Segment],
+            providerMetadata: [String: String]? = nil
         ) {
             self.id = id
             self.assetIDs = assetIDs
             self.segments = segments
+            self.providerMetadata = providerMetadata
         }
     }
 

--- a/Sources/AnyLanguageModel/Transcript.swift
+++ b/Sources/AnyLanguageModel/Transcript.swift
@@ -314,8 +314,6 @@ public struct Transcript: Sendable, Equatable, Codable {
 
         private var calls: [ToolCall]
 
-        /// Opaque, provider-specific state attached to the model turn containing these calls.
-        /// Synthesized Codable preserves this state when saving or replaying a transcript.
         internal var providerMetadata: [String: String]?
 
         public init<S>(id: String = UUID().uuidString, _ calls: S)
@@ -397,8 +395,6 @@ public struct Transcript: Sendable, Equatable, Codable {
         /// Ordered prompt segments.
         public var segments: [Segment]
 
-        /// Opaque, provider-specific state attached to this response.
-        /// Synthesized Codable preserves this state when saving or replaying a transcript.
         internal var providerMetadata: [String: String]?
 
         public init(

--- a/Tests/AnyLanguageModelTests/GeminiThoughtSignatureTests.swift
+++ b/Tests/AnyLanguageModelTests/GeminiThoughtSignatureTests.swift
@@ -131,6 +131,195 @@ import Testing
             // The tool call is replayed once, still signed, however many turns later.
             #expect(try functionCallSignatures(in: bodies[3]) == [Self.signature])
         }
+        private func response(parts: [[String: Any]]) throws -> String {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "candidates": [
+                    [
+                        "content": ["role": "model", "parts": parts],
+                        "finishReason": "STOP",
+                    ]
+                ]
+            ])
+            return String(decoding: data, as: UTF8.self)
+        }
+
+        private func contents(in body: Data) throws -> [[String: Any]] {
+            let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            return try #require(json["contents"] as? [[String: Any]])
+        }
+
+        private func expectParts(_ expected: [[String: Any]], in content: [String: Any]) throws {
+            let actual = try #require(content["parts"] as? [[String: Any]])
+            #expect(NSArray(array: actual).isEqual(to: expected))
+        }
+
+        private func restoredSession(_ session: LanguageModelSession) throws -> LanguageModelSession {
+            let data = try JSONEncoder().encode(session.transcript)
+            let transcript = try JSONDecoder().decode(Transcript.self, from: data)
+            return LanguageModelSession(model: makeModel(), tools: [WeatherTool()], transcript: transcript)
+        }
+
+        @Test("round-trips semantic arguments through sequential calls and later turns")
+        func roundTripsArguments() async throws {
+            StubURLProtocol.reset()
+            let arguments: [[String: Any]] = [
+                [
+                    "city": "Paris", "kind": "ordinary parameter", "id": "user-id",
+                    "enabled": true, "count": 42, "ratio": 1.25, "nothing": NSNull(),
+                    "nested": ["kind": "nested parameter", "items": ["hello", false, 2.5, NSNull(), ["x": 1]]],
+                    "emptyObject": [String: String](), "emptyArray": [String](),
+                ],
+                ["city": "London", "kind": ["type": "user data"], "enabled": false, "count": -3],
+            ]
+            let signatures = [Self.signature, "second-signature=="]
+            let callParts: [[String: Any]] = zip(arguments, signatures).map { args, signature in
+                ["functionCall": ["name": "getWeather", "args": args], "thoughtSignature": signature]
+            }
+            for part in callParts {
+                StubURLProtocol.enqueue(json: try response(parts: [part]))
+            }
+            StubURLProtocol.enqueue(json: textResponse("Both cities are sunny."))
+            StubURLProtocol.enqueue(json: textResponse("Paris and London."))
+            StubURLProtocol.enqueue(json: textResponse("Two cities."))
+
+            let session = LanguageModelSession(model: makeModel(), tools: [WeatherTool()])
+            _ = try await session.respond(to: "Check both cities")
+            _ = try await session.respond(to: "Which cities?")
+            let restored = try restoredSession(session)
+            _ = try await restored.respond(to: "How many?")
+
+            let bodies = StubURLProtocol.recordedBodies
+            try #require(bodies.count == 5)
+            #expect(try bodies.map { try contentCount(in: $0) } == [1, 3, 5, 7, 9])
+            for requestIndex in 1 ..< bodies.count {
+                let history = try contents(in: bodies[requestIndex])
+                try expectParts([callParts[0]], in: history[1])
+                if requestIndex >= 2 {
+                    try expectParts([callParts[1]], in: history[3])
+                }
+                #expect(
+                    try functionCallSignatures(in: bodies[requestIndex])
+                        == Array(signatures.prefix(min(requestIndex, 2)))
+                )
+            }
+            let outputs = session.transcript.compactMap { entry -> String? in
+                guard case .toolOutput(let output) = entry else { return nil }
+                return output.segments.compactMap {
+                    if case .text(let text) = $0 { return text.content }
+                    if case .structure(let structure) = $0 { return structure.content.jsonString }
+                    return nil
+                }.joined()
+            }
+            #expect(outputs.count == 2)
+            #expect(outputs.first?.contains("Paris") == true)
+            #expect(outputs.last?.contains("London") == true)
+        }
+
+        @Test("preserves text signatures and part boundaries through saved conversation history")
+        func roundTripsTextParts() async throws {
+            StubURLProtocol.reset()
+            let parts: [[String: Any]] = [
+                ["text": "Thinking.", "thought": true, "thoughtSignature": "thinking-signature=="],
+                ["text": "Hello "],
+                ["text": "world.", "thoughtSignature": Self.signature],
+            ]
+            StubURLProtocol.enqueue(json: try response(parts: parts))
+            StubURLProtocol.enqueue(json: textResponse("Again."))
+            StubURLProtocol.enqueue(json: textResponse("Still here."))
+            let session = LanguageModelSession(model: makeModel())
+            let result = try await session.respond(to: "Hello")
+            #expect(result.content == "Thinking.Hello world.")
+            #expect(result.providerMetadata != nil)
+            _ = try await session.respond(to: "Continue")
+            let restored = try restoredSession(session)
+            _ = try await restored.respond(to: "Continue again")
+
+            let bodies = StubURLProtocol.recordedBodies
+            try #require(bodies.count == 3)
+            #expect(try bodies.map { try contentCount(in: $0) } == [1, 3, 5])
+            for body in bodies.dropFirst() {
+                try expectParts(parts, in: contents(in: body)[1])
+            }
+        }
+
+        @Test("preserves signed text siblings in a tool-call turn")
+        func roundTripsMixedParts() async throws {
+            StubURLProtocol.reset()
+            let parts: [[String: Any]] = [
+                ["text": "Checking.", "thoughtSignature": "before-call=="],
+                [
+                    "functionCall": ["name": "getWeather", "args": ["city": "Paris"]],
+                    "thoughtSignature": Self.signature,
+                ],
+                ["text": "Then London."],
+                ["functionCall": ["name": "getWeather", "args": ["city": "London"]]],
+                ["text": "Waiting.", "thoughtSignature": "after-call=="],
+            ]
+            StubURLProtocol.enqueue(json: try response(parts: parts))
+            StubURLProtocol.enqueue(json: textResponse("Sunny."))
+            StubURLProtocol.enqueue(json: textResponse("Both cities."))
+            let session = LanguageModelSession(model: makeModel(), tools: [WeatherTool()])
+            _ = try await session.respond(to: "Check the weather")
+            let restored = try restoredSession(session)
+            _ = try await restored.respond(to: "Where?")
+
+            let bodies = StubURLProtocol.recordedBodies
+            try #require(bodies.count == 3)
+            #expect(try bodies.map { try contentCount(in: $0) } == [1, 4, 6])
+            for body in bodies.dropFirst() {
+                try expectParts(parts, in: contents(in: body)[1])
+            }
+        }
+
+        @Test("preserves signed structured responses")
+        func roundTripsStructuredResponse() async throws {
+            StubURLProtocol.reset()
+            let parts: [[String: Any]] = [
+                ["text": #"{"city": "Paris"}"#, "thoughtSignature": Self.signature]
+            ]
+            StubURLProtocol.enqueue(json: try response(parts: parts))
+            StubURLProtocol.enqueue(json: textResponse("Paris."))
+            let session = LanguageModelSession(model: makeModel())
+            let result = try await session.respond(to: "Pick a city", generating: WeatherTool.Arguments.self)
+            #expect(result.content.city == "Paris")
+            _ = try await session.respond(to: "Which city?")
+            let bodies = StubURLProtocol.recordedBodies
+            try #require(bodies.count == 2)
+            try expectParts(parts, in: contents(in: bodies[1])[1])
+        }
+
+        @Test("preserves a streaming signature arriving after the final text", arguments: [true, false])
+        func roundTripsStreamingSignature(omitsText: Bool) async throws {
+            StubURLProtocol.reset()
+            var signaturePart: [String: Any] = ["thoughtSignature": Self.signature]
+            if !omitsText { signaturePart["text"] = "" }
+            StubURLProtocol.enqueue(
+                eventStream: try [
+                    response(parts: [["text": "Hello "]]),
+                    response(parts: [["text": "world."]]),
+                    response(parts: [signaturePart]),
+                ]
+            )
+            StubURLProtocol.enqueue(json: textResponse("Again."))
+            let session = LanguageModelSession(model: makeModel())
+            let result = try await session.streamResponse(to: "Hello").collect()
+            #expect(result.content == "Hello world.")
+            #expect(result.providerMetadata != nil)
+            let restored = try restoredSession(session)
+            _ = try await restored.respond(to: "Continue")
+
+            let bodies = StubURLProtocol.recordedBodies
+            try #require(bodies.count == 2)
+            #expect(try contentCount(in: bodies[1]) == 3)
+            try expectParts(
+                [
+                    ["text": "Hello "], ["text": "world."],
+                    ["text": "", "thoughtSignature": Self.signature],
+                ],
+                in: contents(in: bodies[1])[1]
+            )
+        }
+
     }
 
 #endif

--- a/Tests/AnyLanguageModelTests/GeminiThoughtSignatureTests.swift
+++ b/Tests/AnyLanguageModelTests/GeminiThoughtSignatureTests.swift
@@ -131,6 +131,7 @@ import Testing
             // The tool call is replayed once, still signed, however many turns later.
             #expect(try functionCallSignatures(in: bodies[3]) == [Self.signature])
         }
+
         private func response(parts: [[String: Any]]) throws -> String {
             let data = try JSONSerialization.data(withJSONObject: [
                 "candidates": [

--- a/Tests/AnyLanguageModelTests/Shared/StubURLProtocol.swift
+++ b/Tests/AnyLanguageModelTests/Shared/StubURLProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
         struct Exchange: Sendable {
             var statusCode: Int = 200
             var body: Data
+            var contentType: String = "application/json"
         }
 
         private struct State: Sendable {
@@ -27,6 +28,14 @@ import Foundation
         /// Queues one JSON response, returned to the next request that arrives.
         static func enqueue(json: String, statusCode: Int = 200) {
             state.withLock { $0.pending.append(Exchange(statusCode: statusCode, body: Data(json.utf8))) }
+        }
+
+        /// Queues a finite server-sent event stream.
+        static func enqueue(eventStream: [String]) {
+            let body = eventStream.map { "data: \($0)\n\n" }.joined()
+            state.withLock {
+                $0.pending.append(Exchange(body: Data(body.utf8), contentType: "text/event-stream"))
+            }
         }
 
         /// The bodies of the requests seen so far, in order.
@@ -63,7 +72,7 @@ import Foundation
                 url: url,
                 statusCode: exchange.statusCode,
                 httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
+                headerFields: ["Content-Type": exchange.contentType]
             )!
 
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)

--- a/Tests/AnyLanguageModelTests/Shared/StubURLProtocol.swift
+++ b/Tests/AnyLanguageModelTests/Shared/StubURLProtocol.swift
@@ -30,7 +30,6 @@ import Foundation
             state.withLock { $0.pending.append(Exchange(statusCode: statusCode, body: Data(json.utf8))) }
         }
 
-        /// Queues a finite server-sent event stream.
         static func enqueue(eventStream: [String]) {
             let body = eventStream.map { "data: \($0)\n\n" }.joined()
             state.withLock {

--- a/Tests/AnyLanguageModelTests/TranscriptTests.swift
+++ b/Tests/AnyLanguageModelTests/TranscriptTests.swift
@@ -169,4 +169,22 @@ struct TranscriptTests {
 
         #expect(decoded.providerMetadata == ["thoughtSignature": "opaque-signature"])
     }
+    @Test func responseAndToolCallsRoundTripProviderMetadata() throws {
+        let metadata = ["provider.state": "opaque-signature"]
+        for metadata in [nil, metadata] {
+            let response = Transcript.Response(assetIDs: [], segments: [], providerMetadata: metadata)
+            let calls = Transcript.ToolCalls([Transcript.ToolCall](), providerMetadata: metadata)
+            let responseData = try JSONEncoder().encode(response)
+            let callsData = try JSONEncoder().encode(calls)
+            #expect(try JSONDecoder().decode(Transcript.Response.self, from: responseData) == response)
+            #expect(try JSONDecoder().decode(Transcript.ToolCalls.self, from: callsData) == calls)
+            if metadata == nil {
+                let responseJSON = try #require(try JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+                let callsJSON = try #require(try JSONSerialization.jsonObject(with: callsData) as? [String: Any])
+                #expect(responseJSON["providerMetadata"] == nil)
+                #expect(callsJSON["providerMetadata"] == nil)
+            }
+        }
+    }
+
 }

--- a/Tests/AnyLanguageModelTests/TranscriptTests.swift
+++ b/Tests/AnyLanguageModelTests/TranscriptTests.swift
@@ -169,6 +169,7 @@ struct TranscriptTests {
 
         #expect(decoded.providerMetadata == ["thoughtSignature": "opaque-signature"])
     }
+
     @Test func responseAndToolCallsRoundTripProviderMetadata() throws {
         let metadata = ["provider.state": "opaque-signature"]
         for metadata in [nil, metadata] {
@@ -186,5 +187,4 @@ struct TranscriptTests {
             }
         }
     }
-
 }


### PR DESCRIPTION
Gemini conversation history currently wraps tool arguments in `GeneratedContent`’s persistence format and drops thought signatures on text parts. This PR replays arguments from their semantic JSON and preserve signed text with its original part boundaries and position among tool calls.

Fixes #235
Fixes #221

