### PR TITLE
Fix structured generation for arrays of Generable types

### DIFF
--- a/Sources/AnyLanguageModel/Generable.swift
+++ b/Sources/AnyLanguageModel/Generable.swift
@@ -326,10 +326,13 @@ extension Array: Generable where Element: Generable {
             minItems: nil,
             maxItems: nil
         )
-        return GenerationSchema.primitive(
+        var schema = GenerationSchema.primitive(
             [Element].self,
             node: .array(arrayNode)
         )
+        // Array items can reference the element type and its nested dependencies.
+        schema.defs = elementSchema.defs
+        return schema
     }
 }
 

--- a/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
+++ b/Sources/AnyLanguageModel/Models/SystemLanguageModel.swift
@@ -641,7 +641,9 @@
             return .init(arrayOf: itemsSchema, minimumElements: minItems, maximumElements: maxItems)
 
         case .reference(let name):
-            return .init(referenceTo: name)
+            let prefix = "#/$defs/"
+            let typeName = name.hasPrefix(prefix) ? String(name.dropFirst(prefix.count)) : name
+            return .init(referenceTo: typeName)
 
         case .allOf, .oneOf, .not, .null, .empty, .any:
             return .init(type: String.self)

--- a/Tests/AnyLanguageModelTests/ArrayGenerationSchemaTests.swift
+++ b/Tests/AnyLanguageModelTests/ArrayGenerationSchemaTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import AnyLanguageModel
+
+@Suite("Array Generation Schema")
+struct ArrayGenerationSchemaTests {
+    @Generable
+    struct Item {
+        var name: String
+        var count: Int
+    }
+
+    @Generable
+    struct Response {
+        var title: String
+        var items: [Item]
+    }
+
+    @Generable
+    struct NestedItem {
+        var item: Item
+        var relatedItems: [Item]
+    }
+
+    @Generable
+    struct OptionalResponse {
+        @Guide(description: "Suggested items", .count(2))
+        var items: [NestedItem]?
+    }
+
+    @Test func arraysPreserveElementDefinitions() throws {
+        try checkArraySchema(Item.self)
+        try checkArraySchema(NestedItem.self)
+        try checkArraySchema([Item].self)
+        try checkArraySchema(String.self)
+    }
+
+    private func checkArraySchema<Element: Generable>(_ type: Element.Type) throws {
+        let elementSchema = Element.generationSchema
+        let schema = [Element].generationSchema
+        guard case .array(let array) = schema.root else {
+            Issue.record("Expected an array schema for \(Element.self)")
+            return
+        }
+        #expect(array.items == elementSchema.root)
+        #expect(schema.defs == elementSchema.defs)
+
+        let data = try JSONEncoder().encode(schema)
+        let decoded = try JSONDecoder().decode(GenerationSchema.self, from: data)
+        #expect(decoded == schema)
+        #expect(decoded.defs == elementSchema.defs)
+    }
+
+    @Test func objectArrayPropertyEncodesElementDefinition() throws {
+        let data = try JSONEncoder().encode(Response.generationSchema)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let definitions = try #require(json["$defs"] as? [String: Any])
+        let response = try #require(definitions[String(reflecting: Response.self)] as? [String: Any])
+        let properties = try #require(response["properties"] as? [String: Any])
+        let array = try #require(properties["items"] as? [String: Any])
+        #expect(array["type"] as? String == "array")
+        let items = try #require(array["items"] as? [String: Any])
+        let itemName = String(reflecting: Item.self)
+        #expect(items["$ref"] as? String == "#/$defs/\(itemName)")
+
+        let item = try #require(definitions[itemName] as? [String: Any])
+        let itemProperties = try #require(item["properties"] as? [String: Any])
+        #expect((itemProperties["name"] as? [String: Any])?["type"] as? String == "string")
+        #expect((itemProperties["count"] as? [String: Any])?["type"] as? String == "integer")
+        #expect(Set(item["required"] as? [String] ?? []) == ["name", "count"])
+    }
+
+    @Test func optionalArrayPreservesTransitiveDefinitionsAndGuides() throws {
+        let schema = OptionalResponse.generationSchema
+        let root = try #require(schema.withResolvedRoot())
+        guard case .object(let object) = root.root,
+            case .array(let array) = object.properties["items"]
+        else {
+            Issue.record("Expected an object with an array property")
+            return
+        }
+        #expect(!object.required.contains("items"))
+        #expect(array.description == "Suggested items")
+        #expect(array.minItems == 2)
+        #expect(array.maxItems == 2)
+        #expect(array.items == NestedItem.generationSchema.root)
+        for (name, definition) in NestedItem.generationSchema.defs {
+            #expect(schema.defs[name] == definition)
+        }
+        let itemName = String(reflecting: Item.self)
+        #expect(schema.defs[itemName] == Item.generationSchema.defs[itemName])
+    }
+}

--- a/Tests/AnyLanguageModelTests/DynamicSchemaConversionTests.swift
+++ b/Tests/AnyLanguageModelTests/DynamicSchemaConversionTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 
 @testable import AnyLanguageModel
 
@@ -194,11 +195,17 @@ import Testing
         }
 
         @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-        @Test func convertReferenceSchema() {
-            let schema: JSONSchema = .reference("SomeType")
-            // Reference schemas need the referenced type in dependencies
-            // This test just verifies the conversion doesn't crash
-            _ = convertToDynamicSchema(schema)
+        @Test(arguments: ["SomeType", "#/$defs/SomeType"])
+        func convertReferenceSchema(reference: String) throws {
+            let schema: JSONSchema = .reference(reference)
+            let dependency = FoundationModels.DynamicGenerationSchema(
+                name: "SomeType",
+                properties: [.init(name: "value", schema: .init(type: String.self))]
+            )
+            _ = try FoundationModels.GenerationSchema(
+                root: convertToDynamicSchema(schema),
+                dependencies: [dependency]
+            )
         }
 
         @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
@@ -346,6 +353,16 @@ import Testing
         }
 
         // MARK: - Integration with AnyLanguageModel.GenerationSchema
+
+        @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+        @Test func convertSchemaWithGenerableArrayProperty() throws {
+            let schema = FoundationModels.GenerationSchema(ArrayGenerationSchemaTests.Response.generationSchema)
+            let data = try JSONEncoder().encode(schema)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let properties = try #require(json["properties"] as? [String: Any])
+            #expect(properties["title"] != nil)
+            #expect(properties["items"] != nil)
+        }
 
         @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
         @Test func convertFromAnyLanguageModelGenerationSchema() {


### PR DESCRIPTION
Preserves element definitions and nested dependencies in array schemas so arrays of `@Generable` types produce valid structured-generation schemas. Converts JSON schema reference paths to type names for Foundation Models, preventing conversion from falling back to an empty schema.

Fixes #155
